### PR TITLE
Added Privacy & Terms Pages

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -33,6 +33,8 @@ import Login from './pages/Login'
 import Signup from './pages/Signup'
 import Dashboard from './pages/Dashboard'
 import ProtectedRoute from './components/Auth/ProtectedRoute'
+import PrivacyPolicy from './pages/Privacypolicy.jsx'
+import TermsAndConditions from './pages/Terms&Conditions.jsx'
 
 import FAQ from './pages/FAQ.jsx'
 import { AuthProvider } from './context/AuthContext'
@@ -63,7 +65,8 @@ const router = createBrowserRouter([
       { path: '/faq', element: <FAQ /> },
 
       { path: '/contact', element: <Contact /> },
-
+      { path: '/privacy', element: <PrivacyPolicy /> },
+      { path: '/terms', element: <TermsAndConditions /> },
       {
         path: '/dashboard',
         element: (

--- a/client/src/pages/Privacypolicy.jsx
+++ b/client/src/pages/Privacypolicy.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import Navbar from '../components/Custom/Navbar';
+
+
+export default function PrivacyPolicy() {
+  return (
+    <>
+    <Navbar />
+    <div className="bg-white p-8 rounded-lg shadow-lg">
+      <h2 className="text-4xl font-extrabold text-gray-800 mb-6 text-center">Privacy Policy</h2>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">1. Introduction</h3>
+        <p className="text-gray-600 leading-relaxed">
+          Welcome to TravelGrid. We are committed to protecting your privacy and handling your data in an open and transparent manner. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website <span className="font-bold">(the "Service")</span>. Please read this policy carefully. If you do not agree with the terms of this privacy policy, please do not access the site.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">2. Information We Collect</h3>
+        <p className="text-gray-600 leading-relaxed mb-4">
+          We may collect information about you in a variety of ways. The information we may collect on the Site includes:
+        </p>
+        <ul className="list-disc list-inside text-gray-600 ml-4 space-y-2">
+          <li>
+            <strong>Personal Data:</strong> Personally identifiable information, such as your name, shipping address, email address, and telephone number, and demographic information, such as your age, gender, hometown, and interests, that you voluntarily give to us when you register with the Site or when you choose to participate in various activities related to the Site, such as online chat and message boards.
+          </li>
+          <li>
+            <strong>Derivative Data:</strong> Information our servers automatically collect when you access the Site, such as your IP address, your browser type, your operating system, your access times, and the pages you have viewed directly before and after accessing the Site.
+          </li>
+          <li>
+            <strong>Financial Data:</strong> Financial information, such as data related to your payment method (e.g., valid credit card number, card brand, expiration date) that we may collect when you purchase, order, return, exchange, or request information about our services from the Site.
+          </li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">3. How We Use Your Information</h3>
+        <p className="text-gray-600 leading-relaxed mb-4">
+          Having accurate information about you permits us to provide you with a smooth, efficient, and customized experience. Specifically, we may use information collected about you via the Site to:
+        </p>
+        <ul className="list-disc list-inside text-gray-600 ml-4 space-y-2">
+          <li>Create and manage your account.</li>
+          <li>Process your transactions and send you related information.</li>
+          <li>Enable user-to-user communications.</li>
+          <li>Request feedback and contact you about your use of the Site.</li>
+          <li>Deliver targeted advertising, coupons, newsletters, and other information regarding promotions and the Site to you.</li>
+          <li>Resolve disputes and troubleshoot problems.</li>
+          <li>Respond to product and customer service requests.</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">4. Disclosure of Your Information</h3>
+        <p className="text-gray-600 leading-relaxed mb-4">
+          We may share information we have collected about you in certain situations. Your information may be disclosed as follows:
+        </p>
+        <ul className="list-disc list-inside text-gray-600 ml-4 space-y-2">
+          <li>
+            <strong>By Law or to Protect Rights:</strong> If we believe the release of information about you is necessary to respond to legal process, to investigate or remedy potential violations of our policies, or to protect the rights, property, and safety of others, we may share your information as permitted or required by any applicable law, rule, or regulation.
+          </li>
+          <li>
+            <strong>Third-Party Service Providers:</strong> We may share your information with third parties that perform services for us or on our behalf, including payment processing, data analysis, email delivery, hosting services, customer service, and marketing assistance.
+          </li>
+          <li>
+            <strong>Marketing Communications:</strong> With your consent, or with an opportunity for you to withdraw consent, we may share your information with third parties for marketing purposes, as permitted by law.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">5. Contact Us</h3>
+        <p className="text-gray-600 leading-relaxed">
+          If you have questions or comments about this Privacy Policy, please contact us at: <a href="mailto:privacy@travelgrid.com" className="text-pink-500 hover:underline">privacy@travelgrid.com</a>
+        </p>
+      </section>
+    </div>
+    </>
+  );
+};

--- a/client/src/pages/Terms&Conditions.jsx
+++ b/client/src/pages/Terms&Conditions.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import Navbar from '../components/Custom/Navbar';
+
+
+export default function TermsAndConditions() {
+  return (
+    <>
+    <Navbar />
+    <div className="bg-white p-8 rounded-lg shadow-lg">
+      <h2 className="text-4xl font-extrabold text-gray-800 mb-6 text-center">Terms & Conditions</h2>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">1. Acceptance of Terms</h3>
+        <p className="text-gray-600 leading-relaxed">
+          By accessing or using the TravelGrid website <span className="font-bold">(the "Service")</span>, you agree to be bound by these Terms and Conditions and our Privacy Policy. If you do not agree to all the terms and conditions of this agreement, then you may not access the website or use any services.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">2. Use of the Service</h3>
+        <p className="text-gray-600 leading-relaxed mb-4">
+          TravelGrid provides an online platform that allows users to browse, compare, and book travel-related services such as flights, hotels, packages, and activities. You agree to use the Service only for lawful purposes and in a way that does not infringe the rights of, restrict or inhibit anyone else's use and enjoyment of the Service.
+        </p>
+        <ul className="list-disc list-inside text-gray-600 ml-4 space-y-2">
+          <li>You must be at least 18 years old to use this Service.</li>
+          <li>You are responsible for maintaining the confidentiality of your account and password.</li>
+          <li>All information you provide must be accurate, complete, and current.</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">3. Bookings and Payments</h3>
+        <p className="text-gray-600 leading-relaxed mb-4">
+          When you make a booking through TravelGrid, you are entering into a contract directly with the travel service provider (e.g., airline, hotel). TravelGrid acts solely as an intermediary.
+        </p>
+        <ul className="list-disc list-inside text-gray-600 ml-4 space-y-2">
+          <li>Prices are subject to change without notice until a booking is confirmed.</li>
+          <li>Payment must be made in full at the time of booking unless otherwise specified.</li>
+          <li>Cancellation and refund policies are determined by the individual service providers and will be clearly stated at the time of booking.</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">4. Intellectual Property</h3>
+        <p className="text-gray-600 leading-relaxed">
+          All content on the TravelGrid website, including text, graphics, logos, images, and software, is the property of TravelGrid or its content suppliers and is protected by international copyright laws. You may not reproduce, distribute, modify, or create derivative works of any content without our express written permission.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">5. Disclaimer of Warranties</h3>
+        <p className="text-gray-600 leading-relaxed">
+          The Service is provided on an "as is" and "as available" basis. TravelGrid makes no representations or warranties of any kind, express or implied, as to the operation of the Service or the information, content, materials, or products included on the Service.
+        </p>
+      </section>
+
+      <section>
+        <h3 className="text-2xl font-semibold text-gray-700 mb-3">6. Governing Law</h3>
+        <p className="text-gray-600 leading-relaxed">
+          These Terms and Conditions are governed by and construed in accordance with the laws of India, without regard to its conflict of law principles.
+        </p>
+      </section>
+    </div>
+    </>
+  );
+};


### PR DESCRIPTION
# Description:

- This PR adds dedicated Privacy Policy and Terms & Conditions pages to the TravelGrid app.

# Key Changes:

- New Pages: Implemented PrivacyPolicy and TermsAndConditions React components with relevant content.

- Navigation: Added header buttons to switch between these two pages.

- Footer Links: Included direct links to both pages in the application footer.

- Styling: Applied consistent Tailwind CSS styling, matching the TravelGrid brand.


Preview

<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/f60c6b53-b43f-41a3-b4c7-071e9a518472" />


<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/ac2f00a7-43b9-4b0b-9bd4-eb3981d8b31c" />



# Issue fixed #68 