### PR TITLE
Fix: removed extra white space

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -179,8 +179,8 @@ const Navbar = () => {
         </div>
       </div>
 
-      {/* Spacer to prevent content from going under navbar */}
-      <div className="h-[60px]"></div>
+      
+     
     </>
   );
 };


### PR DESCRIPTION
**Title:**  
 Removed unnecessary white space on Contact page whitespace between the navbar and hero section

## Description
This PR removes a redundant div that was causing white space between the navbar and hero section on the Contact page. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
fixes #94  

## Screenshots (if applicable)
N/A

## Additional Notes
Let me know if you'd like any changes or improvements to this fix.
Happy to update the PR!
