### PR TITLE
Solved Issue #183 - added view profile functionality to home page guides section

### DIFF
--- a/client/src/components/Home/TravelGuides.jsx
+++ b/client/src/components/Home/TravelGuides.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useNavigate } from 'react-router-dom';
 
 const guides = [
   {
@@ -41,6 +42,10 @@ const TravelGuides = () => {
     const right = (index + 1) % guides.length;
     return [left, center, right];
   };
+ const navigate = useNavigate();
+ const handleguide=(name)=>{
+   navigate('/guides',{ state: { selectedGuideId: name } });
+ }
 
   return (
     <section className="w-full bg-gradient-to-br from-blue-50 to-pink-50 py-16">
@@ -106,7 +111,7 @@ const TravelGuides = () => {
                     <p className="text-gray-600 text-sm text-center mb-4">
                       {guide.bio}
                     </p>
-                    <button className="bg-zinc-800 hover:bg-zinc-900 text-white font-semibold py-2 px-4 rounded-xl transition-transform transform hover:scale-105">
+                    <button onClick={()=>handleguide(guide.name)} className="bg-zinc-800 hover:bg-zinc-900 text-white font-semibold py-2 px-4 rounded-xl transition-transform transform hover:scale-105">
                       View Profile
                     </button>
                   </motion.div>

--- a/client/src/pages/TravelGuidesProfiles.jsx
+++ b/client/src/pages/TravelGuidesProfiles.jsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import './styles/TravelGuidesCarousel.css';
-
+import { useLocation } from 'react-router-dom';
 
 const guides = [
   {
@@ -58,6 +58,15 @@ const guides = [
 ];
 
 const TravelGuidesCarousel = () => {
+ const location = useLocation();
+ useEffect(() => {
+ if(location.state)
+ {
+  const guidetoview=guides.find(guide=>guide.name==location.state.selectedGuideId)
+  setSelectedGuide(guidetoview);
+ }
+  }, []);
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedGuide, setSelectedGuide] = useState(null);
   const profileRef = useRef(null);
@@ -107,6 +116,8 @@ const TravelGuidesCarousel = () => {
     setSearchResults([]);
     setIsSearching(false);
   };
+
+
 
   return (
     <section className="travel-guides-section" style={{ scrollMarginTop: '80px' }}>


### PR DESCRIPTION
solved issue #183. Added the view profile functionality on home page guide section which takes user to the detailed profile of the guide on the guides page directly as follows:
<img width="1907" height="668" alt="image" src="https://github.com/user-attachments/assets/8a920da5-30a8-40d5-9084-1fe0d76e4f3f" />
<img width="1917" height="674" alt="image" src="https://github.com/user-attachments/assets/593e4003-30a9-4f96-80ad-b787e4cc2d15" />
