### PR TITLE
Fixed Automatic scroll to top when route is changed. (issue 219)

### DIFF
--- a/client/src/components/GoToTopButton.jsx
+++ b/client/src/components/GoToTopButton.jsx
@@ -1,9 +1,27 @@
 // client/src/components/GoToTopButton.jsx
 import React, { useState, useEffect } from 'react';
 import './GoToTopButton.css'; 
+import { useLocation } from 'react-router-dom';
+
 
 const GoToTopButton = () => {
   const [showButton, setShowButton] = useState(false);
+  const {pathname} = useLocation();
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'instant'
+    });
+  },[pathname])
+
 
   useEffect(() => {
     const handleScroll = () => {
@@ -24,12 +42,7 @@ const GoToTopButton = () => {
     };
   }, []); 
 
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth'
-    });
-  };
+  
 
   return (
     <>


### PR DESCRIPTION
**Title:**  
Fixed Automatic scroll to top when route is changed.

## Description
No automatic scroll to top was present when i change the route, every time i have to click scroll to top button,
like if i scroll home and move to any other page, that page is also already scrolled, so now on any route change page will start from top always.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

