### PR TITLE
Added close btn to mobile nav sidebar

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -114,13 +114,22 @@ const Navbar = () => {
         }`}
       >
         <div className="p-5 flex flex-col h-full text-pink-500">
-          {/* Logo */}
-          <Link
-            to="/"
-            className="text-2xl font-bold mb-6 hover:text-pink-400 transition-colors duration-200"
-          >
-            TravelGrid
-          </Link>
+          {/* Header with Logo and Close Button */}
+          <div className="flex justify-between items-center mb-6">
+            <Link
+              to="/"
+              className="text-2xl font-bold hover:text-pink-400 transition-colors duration-200"
+            >
+              TravelGrid
+            </Link>
+            <button
+              onClick={() => setIsSidebarOpen(false)}
+              className="text-pink-500 hover:text-pink-400 transition-colors duration-200 p-1 rounded-md hover:bg-pink-500/10"
+              aria-label="Close menu"
+            >
+              <X size={24} />
+            </button>
+          </div>
 
           {/* Nav Links */}
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
**Title:**  
Add dedicated close button to mobile navigation sidebar

## Description
This PR fixes the poor user experience in the mobile navigation menu by adding a dedicated close button (X icon) positioned in the top-right corner of the sidebar header, next to the "TravelGrid" logo. Previously, users could only close the mobile menu by clicking the overlay outside the menu, which was not intuitive.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot 2025-07-28 112341" src="https://github.com/user-attachments/assets/1e09da04-af4c-4057-9b8b-5ff4bf1689b8" />

## Additional Notes
<!-- Add any other context about the pull request here. --> 
