### PR TITLE
Fixed past date ticket booking issue

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,11 +20,8 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-
-    "react-icons": "^5.5.0",
-
     "react-hot-toast": "^2.5.2",
-
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
     "recharts": "^3.1.0",
     "tailwind-merge": "^3.3.1",

--- a/client/src/pages/TicketBooking.jsx
+++ b/client/src/pages/TicketBooking.jsx
@@ -40,6 +40,12 @@ function TicketBooking() {
   const [submitted, setSubmitted] = useState(false);
   const [booked, setBooked] = useState(false); //adding a booked state variable to keep track if booked or not
 
+  //Function to get today's date for validating depart date for ticker
+  const getToday=()=>{
+    const today = new Date();
+    return today.toISOString().split('T')[0]
+  }
+
   const confirmBooking = () => {
     //function called when flight booked.
     setBooked(true);
@@ -418,6 +424,7 @@ function TicketBooking() {
                     name="depart"
                     required
                     value={form.depart}
+                    min={getToday()}    //gets today's date and validate input using that.
                     onChange={handleChange}
                     className="w-full pl-10 pr-3 py-3 rounded-xl bg-white/90 text-gray-800 focus:outline-none focus:ring-4 focus:ring-pink-500/30"
                   />
@@ -435,6 +442,7 @@ function TicketBooking() {
                       name="return"
                       required
                       value={form.return}
+                      min={form.depart}
                       onChange={handleChange}
                       className="w-full pl-10 pr-3 py-3 rounded-xl bg-white/90 text-gray-800 focus:outline-none focus:ring-4 focus:ring-pink-500/30"
                     />


### PR DESCRIPTION
**Title:**  
This PR fixes past date ticket booking issue. 

## Description
Earlier, when the user selects a past date for ticket booking, the application allows booking a ticket for a past application. However, I have now disabled the option to select a past date, which prevents users from choosing a date before today.

I have also solved the issue for the return date. If a user now selects some date as departure date, then they must choose a date after it for return date.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
fixed #252 

## Screenshots (if applicable)

<img width="233" height="285" alt="image" src="https://github.com/user-attachments/assets/78163d74-5a3b-49a4-9e58-c8d3dfa1bdc4" />
