### PR TITLE
Reduce excessive blank space on Trip Expense Calculator page

### DIFF
--- a/client/src/components/TripExpenseCalculator/ExpenseCalculator.jsx
+++ b/client/src/components/TripExpenseCalculator/ExpenseCalculator.jsx
@@ -14,12 +14,14 @@ const TripExpenseCalculator = () => {
 
     const [mode, setMode] = useState("Individual");
     const [numPeople, setNumPeople] = useState(1);
+    const [height, setheight] = useState(false)
 
     const handleChange = (category, value) => {
         setExpense((prev) => ({
         ...prev,
         [category]: value,
         }));
+        setheight(true);
     };
 
     const total = Object.values(expense).reduce(
@@ -100,9 +102,9 @@ const TripExpenseCalculator = () => {
             </p>
         </div>
 
-        <div className="mt-12 p-8">
+        <div className="mt-2 p-8">
             <h3 className="text-2xl font-bold text-center mb-2 text-gray-900">Expense Breakdown</h3>
-            <ResponsiveContainer width="100%" height={450} >
+            <ResponsiveContainer width="100%" height={height==true?450:0} >
                 <PieChart margin={{ top: 30, bottom: 60 }}>
                     <Pie
                         data={chartData}


### PR DESCRIPTION
**Title:**  
UI Improvement: Reduce Excessive Blank Space on "Trip Expense Calculator" Page

## Description
This pull request addresses issue #286  by minimizing the unnecessary blank space below the "Expense Breakdown" heading on the "Trip Expense Calculator" page. The goal is to enhance the visual layout and make the page more compact and balanced for a better user experience, especially on larger screens.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
Closes #286 

## Screenshots (if applicable)
<img width="1380" height="318" alt="Screenshot 2025-07-29 185054" src="https://github.com/user-attachments/assets/90adff5f-2607-41fc-8a27-8f1181ac306f" />

## Additional Notes
This change improves the user interface by optimizing layout space and contributes to a more professional and user-friendly design.

