### PR TITLE
Fixed discover new places path in dashboard page

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -242,8 +242,9 @@ const Dashboard = () => {
                         Plan your next trip or discover new destinations around the world!
                     </p>
                     <button
-                        onClick={() => navigate('/discover')}
+                        onClick={() => navigate('/DiscovermoreDestination')}
                         className="bg-pink-600 hover:bg-pink-700 text-white px-6 py-2 rounded-lg font-medium transition-all duration-300 cursor-pointer"
+                        
                     >
                         Discover New Places
                     </button>


### PR DESCRIPTION
**Title:**  
Fixed discover new places path in dashboard page

## Description
Earlier discover new places was taking to a unknown footer like section, but now when user clicks it, it takes to suitable discover more desitnations page.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
fixed #297 

## Screenshots (if applicable)
Now it opens this page
<img width="1339" height="531" alt="image" src="https://github.com/user-attachments/assets/9b43a525-a4b6-48be-a7f3-42c7972f86ff" />


