### PR TITLE
Fix : Hotels page hero section title color

### DIFF
--- a/client/src/pages/Hotels.jsx
+++ b/client/src/pages/Hotels.jsx
@@ -65,10 +65,10 @@ const handleLike = async (hotel) => {
       <main className="flex flex-col flex-1 w-full items-center">
         {/* Hero + Search */}
         <section className="w-full py-24 flex flex-col items-center text-center px-4 bg-gradient-to-br from-black to-pink-900">
-          <h1 className="text-4xl md:text-5xl font-extrabold text-gray-800 mb-4">
+          <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4">
             Explore World-Class <span className="text-pink-600">Hotels</span>
           </h1>
-          <p className="text-lg md:text-xl text-gray-600 max-w-2xl mb-8">
+          <p className="text-lg md:text-xl text-white max-w-2xl mb-8">
             Browse and book from our curated list of the top luxury hotels worldwide.
           </p>
           <div className="w-full max-w-lg">


### PR DESCRIPTION
**Title:**  
Fix : Hotels page hero section title color

## Description
changed font color of hotels page hero section title from 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
Fixes #406 

## Screenshots (if applicable)
Before :
<img width="1888" height="980" alt="image" src="https://github.com/user-attachments/assets/39a00980-ac3d-4d05-9550-6f47b4553538" />

after :
<img width="1889" height="1043" alt="image" src="https://github.com/user-attachments/assets/97395af8-d561-40a0-8150-daf387cc779c" />


