### PR TITLE
added expense download option in trip calculator (pdf and excel)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,9 +15,11 @@
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "file-saver": "^2.0.5",
         "framer-motion": "^12.23.9",
         "html2canvas": "^1.4.1",
         "jspdf": "^3.0.1",
+        "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -26,7 +28,8 @@
         "react-router-dom": "^7.6.3",
         "recharts": "^3.1.0",
         "tailwind-merge": "^3.3.1",
-        "typewriter-effect": "^2.22.0"
+        "typewriter-effect": "^2.22.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1945,6 +1948,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2188,6 +2200,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2233,6 +2258,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -2300,6 +2334,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2902,6 +2948,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2974,6 +3026,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -3379,6 +3440,15 @@
         "core-js": "^3.6.0",
         "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+      "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3"
       }
     },
     "node_modules/keyv": {
@@ -4328,6 +4398,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -4677,6 +4759,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4685,6 +4785,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,9 +17,11 @@
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "file-saver": "^2.0.5",
     "framer-motion": "^12.23.9",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.1",
+    "jspdf-autotable": "^5.0.2",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -28,7 +30,8 @@
     "react-router-dom": "^7.6.3",
     "recharts": "^3.1.0",
     "tailwind-merge": "^3.3.1",
-    "typewriter-effect": "^2.22.0"
+    "typewriter-effect": "^2.22.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/client/src/components/TripExpenseCalculator/ExpenseCalculator.jsx
+++ b/client/src/components/TripExpenseCalculator/ExpenseCalculator.jsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import ExpenseInputRow from "./ExpenseInputRow";
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-
+import 'jspdf-autotable';
+import * as XLSX from 'xlsx';
+import { saveAs } from 'file-saver';
+import jsPDF from "jspdf";
+import autoTable from "jspdf-autotable";
 const TripExpenseCalculator = () => {
     const [expense, setExpense] = useState({
         transport: "",
@@ -14,12 +18,12 @@ const TripExpenseCalculator = () => {
 
     const [mode, setMode] = useState("Individual");
     const [numPeople, setNumPeople] = useState(1);
-    const [height, setheight] = useState(false)
+    const [height, setheight] = useState(false);
 
     const handleChange = (category, value) => {
         setExpense((prev) => ({
-        ...prev,
-        [category]: value,
+            ...prev,
+            [category]: value,
         }));
         setheight(true);
     };
@@ -37,9 +41,72 @@ const TripExpenseCalculator = () => {
         .map(([category, value]) => ({
             name: category.charAt(0).toUpperCase() + category.slice(1),
             value: Number(value),
-        }))
+        }));
 
-        const COLORS = ['#f43f5e', '#fb7185', '#fda4af', '#fecdd4', '#fbcfe8', '#f9a8d4'];
+    const COLORS = ['#f43f5e', '#fb7185', '#fda4af', '#fecdd4', '#fbcfe8', '#f9a8d4'];
+
+    // ----------- PDF Export -------------
+const handleDownloadPDF = () => {
+  const doc = new jsPDF();
+
+  doc.setFontSize(18);
+  doc.text("Trip Expense Report", 14, 22);
+
+  const tableColumn = ["Category", "Amount (₹)"];
+  const tableRows = [];
+
+  Object.entries(expense).forEach(([key, val]) => {
+    if (Number(val) > 0) {
+      tableRows.push([
+        key.charAt(0).toUpperCase() + key.slice(1),
+        Number(val).toFixed(2),
+      ]);
+    }
+  });
+
+  tableRows.push([
+    mode === "group" ? "Total (Per Person)" : "Total",
+    displayedTotal.toFixed(2),
+  ]);
+
+  autoTable(doc, {
+    startY: 30,
+    head: [tableColumn],
+    body: tableRows,
+  });
+
+  doc.save("Trip_Expense_Report.pdf");
+};
+
+    // ----------- Excel Export -------------
+    const handleDownloadExcel = () => {
+        const data = Object.entries(expense)
+            .filter(([, val]) => Number(val) > 0)
+            .map(([key, val]) => ({
+                Category: key.charAt(0).toUpperCase() + key.slice(1),
+                Amount: Number(val),
+            }));
+
+        data.push({
+            Category: mode === "group" ? "Total (Per Person)" : "Total",
+            Amount: displayedTotal,
+        });
+
+        const worksheet = XLSX.utils.json_to_sheet(data);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, "Expenses");
+
+        const excelBuffer = XLSX.write(workbook, {
+            bookType: "xlsx",
+            type: "array",
+        });
+
+        const fileData = new Blob([excelBuffer], {
+            type: "application/octet-stream",
+        });
+
+        saveAs(fileData, "Trip_Expense_Report.xlsx");
+    };
 
     return (
     <div className="bg-white/10 backdrop-blur-md  rounded-2xl shadow-2xl p-8 border-white/20 max-w-xl mx-auto my-8 mt-20 text-white">
@@ -102,9 +169,25 @@ const TripExpenseCalculator = () => {
             </p>
         </div>
 
-        <div className="mt-2 p-8">
-            <h3 className="text-2xl font-bold text-center mb-2 ">Expense Breakdown</h3>
-            <ResponsiveContainer width="100%" height={height==true?450:0} >
+        {/* Download Buttons */}
+        <div className="mt-6 flex justify-center gap-4">
+            <button
+                onClick={handleDownloadPDF}
+                className="bg-gradient-to-r from-pink-500 to-rose-500 text-white font-semibold px-4 py-2 rounded-xl hover:opacity-90 transition"
+            >
+                Download PDF
+            </button>
+            <button
+                onClick={handleDownloadExcel}
+                className="bg-pink-100 text-pink-700 font-semibold px-4 py-2 rounded-xl hover:bg-pink-200 transition"
+            >
+                Download Excel
+            </button>
+        </div>
+
+        <div className="mt-8 p-8">
+            <h3 className="text-2xl font-bold text-center mb-2">Expense Breakdown</h3>
+            <ResponsiveContainer width="100%" height={height ? 450 : 0}>
                 <PieChart margin={{ top: 30, bottom: 60 }}>
                     <Pie
                         data={chartData}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,6 +1021,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",


### PR DESCRIPTION
## 🚀 Feature: Added Download Option for Trip Expense Report (PDF + Excel)

### Related Issue
Closes #334

### ✨ What’s New
- Added **Download PDF** and **Download Excel** buttons to the Trip Expense Calculator.
- Exported data reflects **user inputs dynamically** (including all expense fields and totals).
- Supports both:
  - Individual mode
  - Group mode (shows per-person total)

### 📄 PDF Report
- Uses `jspdf` and `jspdf-autotable`.
- Neatly formats all categories and total in table form.
- File is named: `Trip_Expense_Report.pdf`

### 📊 Excel Report
- Uses `xlsx` + `file-saver`.
- File includes same data as PDF.
- File is named: `Trip_Expense_Report.xlsx`

### 💻 UI/UX
- No changes made to layout or styling.
- Buttons are styled consistently with existing design.

### video
https://github.com/user-attachments/assets/f246fc11-7f26-4280-8018-db06ef757ade

### 📦 Dependencies
Make sure these are installed:
```bash
npm install jspdf jspdf-autotable xlsx file-saver



