### PR TITLE
Fix 'buss' typo using PluralMap in TicketBooking page

### DIFF
--- a/client/src/pages/TicketBooking.jsx
+++ b/client/src/pages/TicketBooking.jsx
@@ -162,6 +162,13 @@ function TicketBooking() {
     });
   };
 
+  
+  const pluralMap = {
+      bus: "Buses",
+      train: "Trains",
+      flight: "Flights"
+    };
+
   return (
     <div className="flex flex-col min-h-screen w-full bg-gradient-to-br from-black to-pink-900 overflow-x-hidden">
       <Navbar />
@@ -374,7 +381,7 @@ function TicketBooking() {
               type="submit"
               className="w-full mt-4 py-4 bg-gradient-to-r from-pink-600 to-pink-500 hover:from-pink-500 hover:to-pink-600 text-white font-bold rounded-xl text-lg tracking-wide shadow-lg transition-all hover:shadow-pink-700/50"
             >
-              Search {travelType.charAt(0).toUpperCase() + travelType.slice(1)}s
+              Search {pluralMap[travelType] || (travelType.charAt(0).toUpperCase() + travelType.slice(1) + 's')}
             </button>
           </form>
         </div>


### PR DESCRIPTION
**Title:**  
Fix Typo: Change "buss" to "bus" using PluralMap

## Description
This pull request resolves a minor typo in the TicketBooking.jsx file where the term "buss" was incorrectly used.
The correction replaces it with "bus", and the PluralMap is used to ensure consistency across label handling.

Fixes #447

## Type of Change
- [ ] Bug fix

## Checklist
- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors


## Related Issues
Closes #447


## Additional Notes

The typo in the route label "buss" was due to directly appending 's' to the `travelType`, like this:

```jsx
Search {travelType.charAt(0).toUpperCase() + travelType.slice(1)}s
```

This caused incorrect pluralization (e.g., "buss" instead of "buses").

To fix this, I introduced a `pluralMap` object to handle correct plural forms:

```js
const pluralMap = {
  bus: "Buses",
  train: "Trains",
  flight: "Flights"
};
```

Then updated the JSX to use:

```jsx
Search {pluralMap[travelType] || (travelType.charAt(0).toUpperCase() + travelType.slice(1) + 's')}
```

This ensures proper and readable pluralization for each travel type, fixing the typo and improving maintainability.

