### PR TITLE
gototop button properly fixed no overlap and in line

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,7 +33,7 @@ function App() {
                 <Outlet />
               </ErrorBoundary>
             </div>
-            <GoToTopButton />
+            <GoToTopButton /> 
             <FeedbackButton />
             <Footer />
           </div>

--- a/client/src/components/GoToTopButton.jsx
+++ b/client/src/components/GoToTopButton.jsx
@@ -37,7 +37,7 @@ const GoToTopButton = () => {
   }, []);
 
   return (
-    <div className="fixed bottom-6 left-6 z-40">
+    <div className="fixed bottom-42 right-6 z-50">
       <button
         className={`w-14 h-14 bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 rounded-full shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-110 flex items-center justify-center cursor-pointer ${
           showButton ? "" : "opacity-0"


### PR DESCRIPTION
**Title:**  
Go to top button fixed
## Description
Earlier this button was overlapping the chat icon as i had mentioned in my issue #445  but was refactored in some commit
but this made the icon appear on the left which was not pleasing this commit shifts it to right along other icons

## Type of Change
- [x] Bug fix
- [x] Refactor


## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
<!--  Fixes  #445 , Closes #445  -->

## Screenshots (if applicable)
Fixed version
<img width="280" height="532" alt="image" src="https://github.com/user-attachments/assets/408bfb92-d241-4088-b0f6-1b1a1a984504" />


## Additional Notes
<!-- Add any other context about the pull request here. --> 
