### PR TITLE
Make Address in Contact Info Clickable to Open in Google Maps

### DIFF
--- a/client/src/components/Custom/Footer.jsx
+++ b/client/src/components/Custom/Footer.jsx
@@ -237,10 +237,15 @@ const Footer = () => {
                       </svg>
                     </div>
                     <div>
-                      <p className="text-gray-300 text-sm">123 Travel Street</p>
-                      <p className="text-gray-300 text-sm">
-                        Adventure City, AC 12345
-                      </p>
+                        <a
+                          href="https://www.google.com/maps?q=123+Travel+Street,+Adventure+City,+AC+12345"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-gray-300 text-sm hover:underline block"
+                        >
+                          123 Travel Street<br />
+                          Adventure City, AC 12345
+                        </a>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Description
This PR enhances the user experience by making the address in the Contact Info section interactive. Previously, the address (123 Travel Street, Adventure City, AC 12345) was static text. Now, clicking the address opens its location in Google Maps in a new tab.

## Type of Change
- feature enhancement
- Improves UX by making it easier for users to locate the physical address.
- Aligns with common web practices for contact information.

## Checklist
- [✓ ] My code follows the project style guidelines
- [ ✓] I have performed a self-review of my code
- [✓ ] I have commented my code, particularly in hard-to-understand areas
- [✓ ] My changes generate no new warnings or errors


## Screenshots 
<img width="624" height="656" alt="image" src="https://github.com/user-attachments/assets/931d7185-12c2-4907-a197-b1ff0c360057" />
<img width="2383" height="1395" alt="image" src="https://github.com/user-attachments/assets/f26480a7-e17b-4268-a00a-2ad8c073ea81" />


## Additional Notes
Please note that the current address (123 Travel Street, Adventure City, AC 12345) is a placeholder and not a real location. Make sure to replace it with the actual address before the final release or production deployment.
