### PR TITLE
Fix: Navbar Dropdown Visibility Issue on Hover

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -112,7 +112,8 @@ const Navbar = () => {
                   >
                     {link.name} <ChevronDown fontSize={16} />
                   </button>
-                  <div className="absolute left-0 mt-0 opacity-0 min-w-[180px] text-white rounded-lg bg-gradient-to-r from-[#1a1a1a] via-[#1a1a1a] to-[#2c1a31] shadow-md group-hover:opacity-100 group-hover:translate-y-2 transition-all duration-300 z-50 p-2">
+                  {/* added invisible and group hover visible it prevents dropdown from being hoverable when hidden */}
+                  <div className="absolute left-0 mt-2 opacity-0 invisible group-hover:visible group-hover:opacity-100 group-hover:translate-y-2 transition-all duration-300 z-50 p-2 min-w-[180px] text-white rounded-lg bg-gradient-to-r from-[#1a1a1a] via-[#1a1a1a] to-[#2c1a31] shadow-md">
                     {link.subitems.map((item) => (
                       <NavLink
                         key={item.label}


### PR DESCRIPTION
**Title:**  
<!-- Give your pull request a clear, descriptive title. -->

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
This PR resolves an issue where navbar dropdowns were appearing even when the cursor was merely near (but not on) the navbar.
Changes include:
~Added invisible and group-hover:visible utility classes to prevent premature hover triggers.
~Ensured dropdowns only appear when the parent element or dropdown itself is actively hovered.
~Improved overall user experience and avoided accidental UI flickering.
Let me know if any additional refinements are needed!



## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors


## Related Issues
<!-- List any related issues, e.g. Fixes #123, Closes #456 -->
closes #488 

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here. --> 
