### PR TITLE
Feedback submission restricted only to logged in users

### DIFF
--- a/client/src/pages/Feedback.jsx
+++ b/client/src/pages/Feedback.jsx
@@ -1,9 +1,14 @@
 import React, { useState } from "react";
 import { Star, Send } from "lucide-react";
 import toast from "react-hot-toast";
+import { useAuth } from "@/context/AuthContext";
+import { useNavigate } from "react-router-dom";
 
 const Feedback = () => {
   // Add CSS to force dropdown to open downward
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const navigate = useNavigate();
+
   React.useEffect(() => {
     const style = document.createElement("style");
     style.textContent = `
@@ -28,17 +33,34 @@ const Feedback = () => {
   const [hoveredRating, setHoveredRating] = useState(0);
   const [isHotelDropdownOpen, setIsHotelDropdownOpen] = useState(false);
   const [isPackageDropdownOpen, setIsPackageDropdownOpen] = useState(false);
+  const [showLoginPrompt, setShowLoginPrompt] = useState(false);
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   const handleRatingClick = (rating) => {
+    //ensure user is authenticated
+    if (!isAuthenticated) {
+      setShowLoginPrompt(true);
+      toast.error("Please login to rate your experience");
+      return;
+    }
     setFormData({ ...formData, rating });
   };
 
   const handleSubmit = (e) => {
     e.preventDefault();
+
+    //ensure user is authenticated
+    if (!isAuthenticated) {
+      setShowLoginPrompt(true);
+      toast.error("Please login to submit feedback. Reloading...");
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
+      return;
+    }
 
     if (!formData.message || formData.rating === 0) {
       toast.error("Please provide your feedback and rating");


### PR DESCRIPTION
**Title:**
Restrict Feedback Access to Logged-In Users with Toast Alert and Reload

**Description:** 
This pull request adds a conditional check to ensure that only logged-in users can submit feedback. If a user who is not authenticated tries to access the feedback form:
         - A toast notification is shown prompting them to log in.
         - The page is automatically reloaded to reset any unintended state.

This improves the overall security and UX by preventing unauthenticated access to the feedback functionality.

**Type of Change:** 
    - Bug fix
    - New feature

**Checklist:**
- [✅] My code follows the project style guidelines
- [✅ ]  I have performed a self-review of my code
- [✅ ]  I have commented my code, particularly in hard-to-understand areas
- [✅ ]  My changes generate no new warnings or errors

**Related Issues:**
Closes #464
 — Feedback should only be submitted by logged-in users.

**Screenshots:**
<img width="1913" height="921" alt="Screenshot 2025-08-03 105004" src="https://github.com/user-attachments/assets/b83263fa-feba-4585-9a4f-e66b071a8452" />
<img width="1920" height="930" alt="Screenshot 2025-08-03 104900" src="https://github.com/user-attachments/assets/221d0dda-2bd7-44c4-a9ba-a70fdc76cdb7" />

**Additional Notes:**
      - Implemented toast notification using the existing alert system for UX consistency.
      - Reload ensures no stale or unauthorized access persists after the alert.
      - If the user is logged in, feedback submission works as expected.

