### PR TITLE
Fix: Correct text color on hover in DiscoverCard component

### DIFF
--- a/client/src/components/DiscoverCard.jsx
+++ b/client/src/components/DiscoverCard.jsx
@@ -32,7 +32,7 @@ function DiscoverCard({
                 <h3 className="text-xl font-semibold text-fuchsia-500 mb-2 group-hover:text-pink-400 transition-colors duration-300">
                     {place.name}
                 </h3>
-                <p className="text-gray-500 text-sm group-hover:text-white transition-colors duration-300 leading-relaxed">{place.description}</p>
+                <p className="text-gray-500 text-sm group-hover:text-black transition-colors duration-300 leading-relaxed">{place.description}</p>
             </div>
             <div className="p-4">
                 <button


### PR DESCRIPTION
What I did:

Fixed an issue where the card description text turned white on hover, making it unreadable.
Updated the DiscoverCard component to apply proper Tailwind CSS utility classes, ensuring good contrast and better readability.
Used group-hover to selectively change text color without affecting overall card design.

Why it matters:

Enhances user experience and accessibility by ensuring text remains visible.
Maintains a clean and professional UI during hover interactions.