### PR TITLE
fix: highlight Booking, Support, Tools tab when dropdown subpages are active #463

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -42,6 +42,22 @@ const Navbar = () => {
   const [isScrolled, setIsScrolled] = useState(false);
 
   const location = useLocation();
+
+  const getActiveParentTab = () => {
+    for (const link of navLinks) {
+      if (link.subitems) {
+        for (const sub of link.subitems) {
+          if (location.pathname.startsWith(sub.path)) {
+            return link.name;
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  const activeParentTab = getActiveParentTab();
+
   const { user, logout, isAuthenticated } = useAuth();
   const { wishlist } = useWishlist();
 
@@ -104,9 +120,11 @@ const Navbar = () => {
               link.subitems ? (
                 <div className="relative group" key={link.name}>
                   <button
-                    className="py-1 px-2 text-md rounded-sm hover:text-pink-500 hover:shadow-lg transition-all duration-300 flex items-center gap-1"
-                    aria-haspopup="menu"
-                    aria-expanded="false"
+                    className={`py-1.5 px-4 text-md font-medium rounded-sm transition-all duration-300 flex items-center gap-1 ${
+                      activeParentTab === link.name
+                        ? "bg-gradient-to-r from-pink-700 to-pink-500 shadow-md text-white"
+                        : "hover:text-pink-500 hover:shadow-sm text-gray-200"
+                    }`}
                   >
                     {link.name} <ChevronDown fontSize={16} />
                   </button>


### PR DESCRIPTION
**Title:**
**fix(navbar): highlight Booking, Support, Tools tab when dropdown subpages are active**

---

## Description

This PR updates the `Navbar.jsx` logic to correctly highlight the parent tabs (Booking, Support, Tools) when any of their respective dropdown subpages are active. Previously, only the exact route would trigger highlighting, which caused confusion when navigating subpages.

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation update
* [ ] Other (please describe):

---

## Checklist

* [x] My code follows the project style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings or errors

---

## Related Issues

Fixes: *No issue number attached (direct UI fix)*
Fixed #463 

---

## Additional Notes

* This change ensures better UX by keeping the navbar state consistent with current routes, even if the user is on a nested subpage.
