### PR TITLE
Add spacing above cards in hotels page

### DIFF
--- a/client/src/pages/Hotels.jsx
+++ b/client/src/pages/Hotels.jsx
@@ -70,7 +70,7 @@ function Hotels() {
           </div>
         </section>
 
-        <section className="max-w-7xl w-full px-4 pb-16 grid gap-10 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <section className="max-w-7xl w-full pt-12 px-4 pb-16 grid gap-10 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {filteredHotels.map((hotel) => (
             <div
               key={hotel.id}


### PR DESCRIPTION
**Title:**  
Add spacing above cards in the Hotels page.

## Description
Before this commit, the Hotel cards in the Hotel section are completely overlapped to the top of the container. I have solved this issue by adding some padding in the top of the page.


## Related Issues
Closes #559 

## Screenshots (if applicable)

Before the changes:
<img width="1881" height="789" alt="image" src="https://github.com/user-attachments/assets/dc09d543-8055-4192-9828-2f8a2c76775a" />


After the changes:
<img width="1895" height="914" alt="image" src="https://github.com/user-attachments/assets/1ec52811-5211-4015-b14c-8eb5a931d898" />


