### PR TITLE
Fix: Add cursor pointer to guides card arrow buttons

### DIFF
--- a/client/src/components/Custom/CustomCarousel.jsx
+++ b/client/src/components/Custom/CustomCarousel.jsx
@@ -21,8 +21,8 @@ const CustomCarousel = ({ guides, viewprofilehandle, isHome = false }) => {
           isDarkMode
             ? "bg-white/10 border border-white/20 hover:bg-white/20 hover:border-white/40"
             : "bg-white/80 border border-gray-200 hover:bg-white hover:border-pink-300"
-        }`}
-      >
+        } cursor-pointer`}>
+            {/* add cursor pointer on prevSlide */}
         <ChevronLeft
           className={`w-6 h-6 ${isDarkMode ? "text-white" : "text-gray-700"}`}
         />
@@ -133,8 +133,8 @@ const CustomCarousel = ({ guides, viewprofilehandle, isHome = false }) => {
           isDarkMode
             ? "bg-white/10 border border-white/20 hover:bg-white/20 hover:border-white/40"
             : "bg-white/80 border border-gray-200 hover:bg-white hover:border-pink-300"
-        }`}
-      >
+        } cursor-pointer`} > 
+        {/* add cursor pointer on nextSlide */}
         <ChevronRight
           className={`w-6 h-6 ${isDarkMode ? "text-white" : "text-gray-700"}`}
         />


### PR DESCRIPTION
## Title
 Add cursor pointer to the guides card arrow buttons.

## Description

I initially thought the guide card images were oval-shaped on my side, but after checking from another account, they appeared correctly shaped. Therefore, I focused on updating the arrow buttons in the guides card slider to use a pointer cursor for better user experience.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
 fixes #749

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
Let me know if you’d like to merge this change or not.
