### PR TITLE
Remove Duplicate Footer from AI-Powered Travel Mood Board Page

### DIFF
--- a/client/src/pages/MoodBoardPage.jsx
+++ b/client/src/pages/MoodBoardPage.jsx
@@ -32,7 +32,7 @@ const MoodBoardPage = () => {
                 </div>
             </main>
 
-            <Footer />
+            
         </div>
     );
 };


### PR DESCRIPTION
**Title:**  
Remove Duplicate Footer from AI-Powered Travel Mood Board Page

---

## Description
This pull request fixes the issue where the AI-Powered Travel Mood Board page displayed two footers simultaneously, creating redundancy and disrupting the visual flow of the page. The duplicate footer has been removed to maintain a clean and consistent layout in line with the overall theme.

---

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues

Fixes Issue: #805 

## Screenshots (if applicable)

Before--
<img width="1883" height="1024" alt="image" src="https://github.com/user-attachments/assets/1032ff37-ffc5-4957-a47d-cf28d96acd49" />


After--
<img width="1878" height="1016" alt="image" src="https://github.com/user-attachments/assets/2498693f-0250-417a-829b-578716b3d3ed" />


