### PR TITLE
Fix extra bottom padding in footer copyright section

### DIFF
--- a/client/src/components/Custom/Footer.jsx
+++ b/client/src/components/Custom/Footer.jsx
@@ -57,7 +57,8 @@ const Footer = () => {
         <div className="absolute inset-0 bg-[url('data:image/svg+xml,...')] opacity-20" />
 
         <div className="relative z-10">
-          <div className="container mx-auto px-4 py-16">
+          {/* remove extra padding in footer */}
+          <div className="container mx-auto px-4 pt-16">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-12 text-left">
               <div className="space-y-6">
   <div className="flex items-center space-x-3">
@@ -245,7 +246,7 @@ const Footer = () => {
             </div>
 
             {/* Bottom Section */}
-            <div className="border-t border-gray-700 mt-12 pt-8 pb-8">
+            <div className="border-t border-gray-700 mt-12 py-6">
               <div className="flex flex-col md:flex-row justify-center items-center text-center space-y-4 md:space-y-0">
                 <div className="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-6">
                   <p className="text-gray-400 text-sm">


### PR DESCRIPTION
## Title
Fix extra bottom padding in footer copyright section.

## Description
This PR fixes the extra bottom padding in the footer copyright section to make the spacing consistent with the navbar. This improves the overall layout alignment and visual consistency.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
Fixes #813 

## Screenshots (if applicable)
 N/A

## Additional Notes
N/A
