### PR TITLE
chore: remove duplicate sidebar useEffect

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -98,10 +98,6 @@ const Navbar = () => {
   };
 
   useEffect(() => {
-    setIsSidebarOpen(false);
-  }, [location.pathname]);
-
-  useEffect(() => {
     document.body.style.overflow = isSidebarOpen ? "hidden" : "auto";
   }, [isSidebarOpen]);
 


### PR DESCRIPTION
# Cleanup: Remove duplicate sidebar effect

## Description
I initially intended to implement the smooth-scroll for the logo. Since I found it was already implemented, I decided to review the code for any issues. During the review, I discovered a duplicate sidebar close effect (`useEffect`) and removed it to clean up the code.

I removed the second duplicate
<img width="554" height="404" alt="image" src="https://github.com/user-attachments/assets/22ba592a-f372-42b0-9d58-afe170bbe1cd" />




Related issue: #839
