### PR TITLE
Consistent Home page's guide section + seperated pet guides

### DIFF
--- a/client/src/components/Home/TravelGuides.jsx
+++ b/client/src/components/Home/TravelGuides.jsx
@@ -22,12 +22,31 @@ const guides = [
     bio: "Wildlife expert and safari guide, specializing in Kenya and Tanzania national parks.",
     image: "https://randomuser.me/api/portraits/men/34.jpg",
   },
+  // added all 3 pet guides for home page
+  {
+    name: "Snowy Kat",
+    expertise: "🐾 Mountain Treks & Pet Adventures",
+    bio: "Passionate about guiding pet parents through scenic mountain trails and nature escapes. Specialist in safe trekking experiences for dogs and cats.",
+    image: "https://randomuser.me/api/portraits/men/17.jpg",
+  },
   {
     name: "Mei Lin",
     expertise: "East Asia Tours",
     bio: "Licensed guide for Japan, China, and South Korea. Loves sharing local traditions and cuisine.",
     image: "https://randomuser.me/api/portraits/women/43.jpg",
   },
+  {
+    name: "Ayushi Uniyal",
+    expertise: "🐾 Pet Travel & Coastal Getaways",
+    bio: "Loves helping travelers explore India’s beaches with their furry companions. Expert in pet-friendly accommodations and transport.",
+    image: "https://randomuser.me/api/portraits/women/17.jpg",
+  },
+  {
+    name: "Weddy Brown",
+    expertise: "🐾 Urban Travel with Pets",
+    bio: "Amsterdam-based guide specializing in navigating cities with pets. Knows every pet-friendly park, café, and stay in the area.",
+    image: "https://randomuser.me/api/portraits/men/74.jpg"
+  }
 ];
 
 const TravelGuides = () => {

--- a/client/src/pages/TravelGuidesProfiles.jsx
+++ b/client/src/pages/TravelGuidesProfiles.jsx
@@ -12,7 +12,7 @@ import CustomCarousel from "../components/Custom/CustomCarousel";
 import { useTheme } from "../context/ThemeContext";
 import "./styles/TravelGuidesCarousel.css";
 
-const guides = [
+const guides1 = [
   {
     name: "Aarav Mehta",
     expertise: "Himalayan Treks",
@@ -65,11 +65,27 @@ const guides = [
       contact: "mei.eastasia@example.com",
     },
   },
+]
+//seperated pet guides and non pet guides with addition of one more pet guide
+const guides = [
+  {
+    name: "Snowy Kat",
+    expertise: "🐾 Mountain Treks & Pet Adventures",
+    bio: "Passionate about guiding pet parents through scenic mountain trails and nature escapes. Specialist in safe trekking experiences for dogs and cats.",
+    image: "https://randomuser.me/api/portraits/men/17.jpg",
+    details: {
+      location: "Manali, India",
+      languages: "English, Hindi, Himachali",
+      certifications: "Certified Pet Adventure Guide (CPAG)",
+      experience: "Led 80+ pet-friendly trekking expeditions",
+      contact: "rohit.petguide@example.com",
+    },
+  },  
   {
     name: "Ayushi Uniyal",
     expertise: "🐾 Pet Travel & Coastal Getaways",
     bio: "Loves helping travelers explore India’s beaches with their furry companions. Expert in pet-friendly accommodations and transport.",
-    image: "https://randomuser.me/api/portraits/women/54.jpg",
+    image: "https://randomuser.me/api/portraits/women/17.jpg",
     details: {
       location: "Goa, India",
       languages: "English, Hindi, Konkani",
@@ -505,7 +521,24 @@ const TravelGuidesCarousel = () => {
         </div>
       ) : (
         // Default Carousel View
-        <CustomCarousel guides={guides} viewprofilehandle={viewProfile} />
+        // seperated pet and non pet guides
+        <>
+        <CustomCarousel guides={guides1} viewprofilehandle={viewProfile} />
+        <p
+          style={{
+            fontSize: "28px",
+            fontWeight: "600",
+            lineHeight: "1.6",
+            marginBottom: "10px",
+            color: isDarkMode ? "#fcfcfc" : "#1f2937",
+            marginBottom:"50px"
+          }}
+        >
+          🐶  Pet Guides  🐱
+        </p>        <CustomCarousel guides={guides} viewprofilehandle={viewProfile} />
+
+        </>
+        
       )}
 
       {selectedGuide && (


### PR DESCRIPTION
**Title:**  
Consistent Home page's guide section + seperated pet guides


## Description
This PR resolved the inconsistencies in the number of guides shown in the guide page and home page, and it separates the pet guides and non-pet guides in the guide page for easy access to both. and it also introduces a new pet guide as earlier there were only 2 pet guides.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
fixed #883 
<!-- PR will not be merged is=f issue number is not mentioned -->

## Screenshots (if applicable)

Added missing guides in home section guides

https://github.com/user-attachments/assets/dc168a71-9b86-4c1c-88fe-b4a473218f82

Separated pet and non-pet guides


https://github.com/user-attachments/assets/3da0b728-aed7-4233-b5ca-64a2344cda85



## Additional Notes
<!-- Add any other context about the pull request here. --> 
