### PR TITLE
Remove redundant language selector above login form

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -66,18 +66,14 @@ const Login = () => {
       <Navbar />
       <div className="pt-24 min-h-screen bg-gradient-to-br from-black to-pink-900 flex items-center justify-center p-4">
         <div className="max-w-md w-full">
-          <div className="flex justify-end mb-4">
-            <LanguageSelector />
-          </div>
-
           {/* Header */}
-          <div className="text-center mb-8">
+          <div className="text-center mb-8 mt-4">
             <h1 className="text-3xl font-bold text-white mb-2">{t("login.title")}</h1>
             <p className="text-gray-300">{t("login.subtitle")}</p>
           </div>
 
           {/* Login Form */}
-          <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 border border-white/20">
+          <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 mb-8 border border-white/20">
             <form onSubmit={handleSubmit} className="space-y-6">
               {error && (
                 <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 flex items-center gap-3">
@@ -158,7 +154,7 @@ const Login = () => {
               <GoogleLoginButton 
                 onSuccess={() => navigate(from, { replace: true })}
                 buttonText={t("login.googleSignIn")}
-                className="w-full"
+                className="w-full rounded-full"
               />
             </form>
 

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -89,18 +89,14 @@ const Signup = () => {
       <Navbar />
       <div className="pt-24 min-h-screen bg-gradient-to-br from-black to-pink-900 flex items-center justify-center p-4">
         <div className="max-w-md w-full">
-          <div className="flex justify-end mb-4">
-            <LanguageSelector />
-          </div>
-
           {/* Header */}
-          <div className="text-center mb-8">
+          <div className="text-center mb-8 mt-4">
             <h1 className="text-3xl font-bold text-white mb-2">{t("signup.title")}</h1>
             <p className="text-gray-300">{t("signup.subtitle")}</p>
           </div>
 
           {/* Signup Form */}
-          <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 border border-white/20">
+          <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 mb-8 border border-white/20">
             <form onSubmit={handleSubmit} className="space-y-6">
               {error && (
                 <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 flex items-center gap-3">


### PR DESCRIPTION
**Title:**  
Remove redundant language selector above login form

## Description
This PR removes the duplicate language selector that appeared above the login form.
The application already has a primary language selector in the header, so having an extra one above the login form was unnecessary and cluttered the UI.

## Type of Change
- ✅ UI/UX Improvement

## Checklist

1. Removed redundant language selector markup from the login page component.
2. Adjusted layout styling to maintain proper spacing after removal.

## Related Issues
Fixes #843 

## Screenshots (if applicable)
Before:
<img width="1890" height="903" alt="Screenshot 2025-08-13 134213" src="https://github.com/user-attachments/assets/b65a12b8-f1dd-4681-8a56-dc636d9f9d5a" />

After:
<img width="1891" height="905" alt="image" src="https://github.com/user-attachments/assets/4fa4c853-f624-4e14-866e-93e8de375c82" />

