### PR TITLE
Improve Trips Page Light mode UI with better background handling, icons, and button styling

### DIFF
--- a/client/src/pages/Trips.jsx
+++ b/client/src/pages/Trips.jsx
@@ -39,34 +39,31 @@ function Trips() {
    const { isDarkMode } = useTheme();
 
   return (
-    <div className={`pt-30 w-full min-h-screen flex flex-col items-center px-4 sm:px-6 lg:px-8 relative text-white${
-        isDarkMode 
-            ? 'bg-black border-pink-500' 
-            : 'bg-white/90 border-pink-200 text-gray-900'
-    }`}
+    <div className={`pt-30 w-full min-h-screen flex flex-col items-center px-4 sm:px-6 lg:px-8 relative `}
     >
-      <h2 className="mt-2 px-2 leading-tight text-2xl sm:text-3xl lg:text-4xl font-bold text-white">
+      <h2 className="mt-2 px-2 leading-tight text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900">
         Planning a Trip?{" "}
-        <span className=" text-pink-400">We've Got You Covered!</span>
+        <span className=" text-pink-500">We've Got You Covered!</span>
       </h2>
       <div className=" pt-16 grid grid-cols-1 md:grid-cols-2 gap-y-6 sm:gap-8 w-full max-w-5xl mb-10 px-4 sm:px-0">
         {TRIP_SUPPORT.map((trip, index) => {
           const Icon = trip.icon;
           return (
             <section
-              className="bg-white/10 shadow-lg p-4 rounded-2xl backdrop-blur-sm hover:bg-white/20 transition duration-300 border border-pink-500 sm:p-6"
+              className={ `shadow-md p-4 rounded-2xl backdrop-blur-lg  transition-all duration-300 border border-pink-400 sm:p-6 ${isDarkMode ? "bg-white/10 hover:bg-white/20":"bg-white/30 hover:bg-white/60"}`} 
+              // light transparent bg color in light mode
               key={index}
             >
-              <span className="bg-white/10 text-pink-300 size-12 flex justify-center items-center rounded-full shadow-pink-md mb-4">
+              <span className={`size-12 flex justify-center items-center rounded-full shadow-md mb-4 ${isDarkMode ? "bg-white/10  text-pink-300":"bg-white text-pink-500"}`}>
+              {/* stronger pink for light mode */}
                 <Icon className="w-6 h-6"/>
               </span>
-              <h3 className="text-left text-lg sm:text-xl font-semibold text-white mb-4">
+              <h3 className="text-left text-lg sm:text-xl font-semibold text-gray-900 mb-4">
                 {trip.title}
               </h3>
               <button aria-label="Search"
                 onClick={() => navigate(trip.path)}
-                className="mt-6 px-4 py-3 sm:px-6 sm:py-4 text-sm sm:text-base bg-pink-500 text-white font-medium rounded-lg hover:bg-gradient-to-r from-pink-500 to-pink-600 hover:scale-105 transition-all duration-300 flex justify-items-start cursor-pointer"
-              >
+                className="mt-6 px-4 py-3 sm:px-6 sm:py-4 text-sm sm:text-base bg-gradient-to-r from-pink-500 to-pink-600 text-white font-medium rounded-lg hover:from-pink-600 hover:to-pink-500 leading-none hover:scale-105 transform transition-all duration-300 flex justify-start items-center cursor-pointer focus:outline-none focus:ring-pink-400 focus:ring-offset-2">
                 {trip.pathName}
               </button>
             </section>


### PR DESCRIPTION

**Title:**  
Improve trips page light mode UI with better background, button styling and  icons.

## Description
Updated the Trips page UI for light mode to improve readability :
- Updated background color and text colors in all elements for better visibility. 
- Making icons and text darker in light mode.
- Fixing button hover effects and some minor typos. 
- Keeping design consistent in both light and dark mode.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
Closes #1112 

## Screenshots (if applicable)
Updated Trips Light mode:

<img width="1450" height="709" alt="trips_light_mode" src="https://github.com/user-attachments/assets/681d4fa3-173f-478b-9526-e11515c5ddc5" />


## Additional Notes
N/A
