### PR TITLE
Feature/theme toggle icon fix

### DIFF
--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1512,6 +1512,11 @@ framer-motion@^12.23.12:
     motion-utils "^12.23.6"
     tslib "^2.4.0"
 
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
**Title:**  
The theme toggle icon was showing the current mode instead of the mode the user would switch to, which was confusing for users.

## Description
- **Sun icon** now shows when in dark mode (indicating "click to switch to light mode")
- **Moon icon** now shows when in light mode (indicating "click to switch to dark mode")
- Updated animated background ring colors to match the new logic

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
This PR closes issue #1143 

## Screenshots (if applicable)
<img width="1599" height="849" alt="image" src="https://github.com/user-attachments/assets/13c676fa-33d2-4dc0-b8f2-d4cb2ff0233e" />
<img width="1596" height="850" alt="image" src="https://github.com/user-attachments/assets/edfce7f1-a26e-408f-bfea-c77060ee141f" />

