### PR TITLE
[Fix] Mood Boards empty state + connect “Explore ideas” → /discover (#1141)

### DIFF
--- a/client/src/components/MoodBoard/MoodBoard.css
+++ b/client/src/components/MoodBoard/MoodBoard.css
@@ -393,3 +393,99 @@
         font-size: 1rem;
     }
 }
+/* ===== MoodBoard Empty States (for unauth & no-boards) ===== */
+.mb-empty-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 480px;
+  padding: 1.5rem;
+}
+
+.mb-empty-card {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  text-align: center;
+  border-radius: 20px;
+  padding: 2.5rem 1.5rem;
+  color: #fff;
+  background: radial-gradient(120% 120% at 0% 0%, #2a0f24 0%, #3b0f30 60%, #1a0f18 100%);
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 10px 30px rgba(236, 72, 153, 0.15);
+  margin: 0 auto;
+}
+
+.mb-empty-card.slim { max-width: 560px; }
+
+.mb-icon {
+  width: 64px;
+  height: 64px;
+  display: block;
+  margin: 0 auto 12px;
+  color: #e879f9; /* fuchsia-400 */
+}
+
+.mb-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0.25rem 0;
+}
+
+.mb-subtitle {
+  color: #d1d5db; /* gray-300 */
+  margin: 0.25rem 0 1rem;
+}
+
+.mb-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.mb-btn-primary,
+.mb-btn-secondary {
+  border: 0;
+  border-radius: 12px;
+  padding: 10px 16px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.mb-btn-primary {
+  background: #ec4899;  /* pink-500 */
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(236, 72, 153, 0.25);
+}
+
+.mb-btn-primary:hover { background: #db2777; }
+
+.mb-btn-secondary {
+  background: rgba(255,255,255,0.12);
+  color: #fff;
+}
+
+.mb-btn-secondary:hover { background: rgba(255,255,255,0.2); }
+
+.mb-hints {
+  margin-top: 12px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  justify-content: center;
+  color: #d1d5db;
+  font-size: 0.95rem;
+}
+
+/* small screens */
+@media (max-width: 480px) {
+  .mb-title { font-size: 1.25rem; }
+  .mb-empty-card { padding: 2rem 1rem; }
+}

--- a/client/src/components/MoodBoard/MoodBoard.jsx
+++ b/client/src/components/MoodBoard/MoodBoard.jsx
@@ -1,16 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-    Palette,
-    Users,
-    Share2,
-    Download,
-    Plus,
-    Sparkles,
-    Heart,
-    MessageCircle,
-    Eye,
-    Settings
+  Palette,
+  Users,
+  Share2,
+  Download,
+  Plus,
+  Sparkles,
+  Heart,
+  MessageCircle,
+  Eye,
+  Settings
 } from 'lucide-react';
 import { useTheme } from '../../context/ThemeContext';
 import { useAuth } from '../../context/AuthContext';
@@ -21,563 +21,603 @@ import AIGenerator from './AIGenerator';
 import { moodBoardService } from '../../services/moodBoardService';
 import toast from 'react-hot-toast';
 import './MoodBoard.css';
+import { useNavigate } from 'react-router-dom';
 
 const MoodBoard = () => {
-    const [isOpen, setIsOpen] = useState(false);
-    const [currentBoard, setCurrentBoard] = useState(null);
-    const [isCollaborating, setIsCollaborating] = useState(false);
-    const [collaborators, setCollaborators] = useState([]);
-    const [showAIGenerator, setShowAIGenerator] = useState(false);
-    const [boards, setBoards] = useState([]);
-    const [selectedBoard, setSelectedBoard] = useState(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const [messages, setMessages] = useState([]);
-    const [selectedElement, setSelectedElement] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentBoard, setCurrentBoard] = useState(null);
+  const [isCollaborating, setIsCollaborating] = useState(false);
+  const [collaborators, setCollaborators] = useState([]);
+  const [showAIGenerator, setShowAIGenerator] = useState(false);
+  const [boards, setBoards] = useState([]);
+  const [selectedBoard, setSelectedBoard] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [selectedElement, setSelectedElement] = useState(null);
 
-    const { isDarkMode } = useTheme();
-    const { isAuthenticated, user } = useAuth();
-    const sidebarRef = useRef(null);
+  const { isDarkMode } = useTheme();
+  const { isAuthenticated, user } = useAuth();
+  const sidebarRef = useRef(null);
+  const navigate = useNavigate();
 
-    // Debug effect to track when the component first mounts
-    useEffect(() => {
-        console.log('MoodBoard: Component mounted with initial state:', {
-            isAuthenticated,
-            user: user ? 'Present' : 'Missing',
-            boardsCount: boards.length,
-            currentBoard: currentBoard ? `ID: ${currentBoard._id}` : 'null',
-            isLoading
-        });
-    }, []); // Empty dependency array means this runs only once on mount
+  // Debug effect to track when the component first mounts
+  useEffect(() => {
+    console.log('MoodBoard: Component mounted with initial state:', {
+      isAuthenticated,
+      user: user ? 'Present' : 'Missing',
+      boardsCount: boards.length,
+      currentBoard: currentBoard ? `ID: ${currentBoard._id}` : 'null',
+      isLoading
+    });
+  }, []); // Empty dependency array means this runs only once on mount
 
-    // Debug effect to track authentication changes
-    useEffect(() => {
-        console.log('MoodBoard: Authentication state changed:', { isAuthenticated, user: user ? 'Present' : 'Missing' });
-    }, [isAuthenticated, user]);
+  // Debug effect to track authentication changes
+  useEffect(() => {
+    console.log('MoodBoard: Authentication state changed:', { isAuthenticated, user: user ? 'Present' : 'Missing' });
+  }, [isAuthenticated, user]);
 
-    // Debug effect to track component re-renders
-    useEffect(() => {
-        console.log('MoodBoard: Component re-rendered with state:', {
-            isAuthenticated,
-            user: user ? 'Present' : 'Missing',
-            boardsCount: boards.length,
-            currentBoard: currentBoard ? `ID: ${currentBoard._id}` : 'null',
-            isLoading
-        });
+  // Debug effect to track component re-renders
+  useEffect(() => {
+    console.log('MoodBoard: Component re-rendered with state:', {
+      isAuthenticated,
+      user: user ? 'Present' : 'Missing',
+      boardsCount: boards.length,
+      currentBoard: currentBoard ? `ID: ${currentBoard._id}` : 'null',
+      isLoading
+    });
+  });
+
+  useEffect(() => {
+    // Load user's existing mood boards
+    console.log('useEffect for authentication triggered - isAuthenticated:', isAuthenticated);
+    if (isAuthenticated) {
+      console.log('User is authenticated, calling loadUserBoards');
+      loadUserBoards();
+    } else {
+      console.log('User is not authenticated, not loading boards');
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    // Load collaborators and messages when a board is opened
+    console.log('useEffect triggered - currentBoard changed:', currentBoard);
+    if (currentBoard && currentBoard._id) {
+      console.log('Calling loadBoardData for board ID:', currentBoard._id);
+      loadBoardData();
+    } else {
+      console.log('No currentBoard or currentBoard._id, not calling loadBoardData');
+    }
+  }, [currentBoard?._id]);
+
+  // Debug effect to track currentBoard changes
+  useEffect(() => {
+    console.log('MoodBoard: currentBoard state changed:', {
+      currentBoard: currentBoard ? `ID: ${currentBoard._id}, Title: ${currentBoard.title}` : 'null'
+    });
+  }, [currentBoard]);
+
+  useEffect(() => {
+    // Track when boards state changes
+    console.log('Boards state changed:', {
+      count: boards.length,
+      boards: boards.map(b => ({ id: b._id, title: b.title }))
     });
 
-    useEffect(() => {
-        // Load user's existing mood boards
-        console.log('useEffect for authentication triggered - isAuthenticated:', isAuthenticated);
-        if (isAuthenticated) {
-            console.log('User is authenticated, calling loadUserBoards');
-            loadUserBoards();
-        } else {
-            console.log('User is not authenticated, not loading boards');
-        }
-    }, [isAuthenticated]);
+    // Auto-select the first board if no board is currently selected and boards exist
+    if (boards.length > 0 && !currentBoard) {
+      console.log('Auto-selecting first board:', boards[0]);
+      setCurrentBoard(boards[0]);
+    }
+  }, [boards, currentBoard]);
 
-    useEffect(() => {
-        // Load collaborators and messages when a board is opened
-        console.log('useEffect triggered - currentBoard changed:', currentBoard);
-        if (currentBoard && currentBoard._id) {
-            console.log('Calling loadBoardData for board ID:', currentBoard._id);
-            loadBoardData();
-        } else {
-            console.log('No currentBoard or currentBoard._id, not calling loadBoardData');
-        }
-    }, [currentBoard?._id]);
+  const loadUserBoards = async () => {
+    try {
+      console.log('loadUserBoards: Starting to load user mood boards');
+      setIsLoading(true);
+      const response = await moodBoardService.getUserMoodBoards();
+      console.log('getUserMoodBoards response:', response);
+      if (response.success) {
+        console.log('Setting boards:', response.data);
+        setBoards(response.data);
+        console.log('Number of boards loaded:', response.data.length);
+      } else {
+        console.error('getUserMoodBoards returned success: false:', response);
+      }
+    } catch (error) {
+      console.error('Error loading boards:', error);
+      console.error('Error details:', {
+        message: error.message,
+        response: error.response,
+        status: error.response?.status,
+        data: error.response?.data
+      });
+      toast.error('Failed to load mood boards');
+    } finally {
+      setIsLoading(false);
+      console.log('loadUserBoards: Finished loading');
+    }
+  };
 
-    // Debug effect to track currentBoard changes
-    useEffect(() => {
-        console.log('MoodBoard: currentBoard state changed:', {
-            currentBoard: currentBoard ? `ID: ${currentBoard._id}, Title: ${currentBoard.title}` : 'null'
-        });
-    }, [currentBoard]);
+  const loadBoardData = async () => {
+    console.log('loadBoardData called with currentBoard:', currentBoard);
+    if (!currentBoard?._id) {
+      console.log('No currentBoard._id, returning early');
+      return;
+    }
 
-    useEffect(() => {
-        // Track when boards state changes
-        console.log('Boards state changed:', {
-            count: boards.length,
-            boards: boards.map(b => ({ id: b._id, title: b.title }))
-        });
+    try {
+      console.log('Attempting to load board data for ID:', currentBoard._id);
+      // Load board details with collaborators and messages
+      const response = await moodBoardService.getMoodBoardById(currentBoard._id);
+      console.log('getMoodBoardById response:', response);
+      if (response.success) {
+        const boardData = response.data;
+        setCurrentBoard(boardData);
+        setCollaborators(boardData.collaborators || []);
+        setMessages(boardData.messages || []);
+        console.log('Board data loaded successfully');
+      } else {
+        console.error('getMoodBoardById returned success: false:', response);
+      }
+    } catch (error) {
+      console.error('Error loading board data:', error);
+      console.error('Error details:', {
+        message: error.message,
+        response: error.response,
+        status: error.response?.status,
+        data: error.response?.data
+      });
+      toast.error('Failed to load board data');
+    }
+  };
 
-        // Auto-select the first board if no board is currently selected and boards exist
-        if (boards.length > 0 && !currentBoard) {
-            console.log('Auto-selecting first board:', boards[0]);
-            setCurrentBoard(boards[0]);
-        }
-    }, [boards, currentBoard]);
+  const createNewBoard = async () => {
+    try {
+      const newBoardData = {
+        title: "New Travel Mood Board",
+        description: "Start creating your travel inspiration board",
+        themes: ["Travel", "Adventure"],
+        activities: ["Sightseeing", "Photography"],
+        colorPalette: ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe']
+      };
 
-    const loadUserBoards = async () => {
-        try {
-            console.log('loadUserBoards: Starting to load user mood boards');
-            setIsLoading(true);
-            const response = await moodBoardService.getUserMoodBoards();
-            console.log('getUserMoodBoards response:', response);
-            if (response.success) {
-                console.log('Setting boards:', response.data);
-                setBoards(response.data);
-                console.log('Number of boards loaded:', response.data.length);
-            } else {
-                console.error('getUserMoodBoards returned success: false:', response);
-            }
-        } catch (error) {
-            console.error('Error loading boards:', error);
-            console.error('Error details:', {
-                message: error.message,
-                response: error.response,
-                status: error.response?.status,
-                data: error.response?.data
-            });
-            toast.error('Failed to load mood boards');
-        } finally {
-            setIsLoading(false);
-            console.log('loadUserBoards: Finished loading');
-        }
-    };
-
-    const loadBoardData = async () => {
-        console.log('loadBoardData called with currentBoard:', currentBoard);
-        if (!currentBoard?._id) {
-            console.log('No currentBoard._id, returning early');
-            return;
-        }
-
-        try {
-            console.log('Attempting to load board data for ID:', currentBoard._id);
-            // Load board details with collaborators and messages
-            const response = await moodBoardService.getMoodBoardById(currentBoard._id);
-            console.log('getMoodBoardById response:', response);
-            if (response.success) {
-                const boardData = response.data;
-                setCurrentBoard(boardData);
-                setCollaborators(boardData.collaborators || []);
-                setMessages(boardData.messages || []);
-                console.log('Board data loaded successfully');
-            } else {
-                console.error('getMoodBoardById returned success: false:', response);
-            }
-        } catch (error) {
-            console.error('Error loading board data:', error);
-            console.error('Error details:', {
-                message: error.message,
-                response: error.response,
-                status: error.response?.status,
-                data: error.response?.data
-            });
-            toast.error('Failed to load board data');
-        }
-    };
-
-    const createNewBoard = async () => {
-        try {
-            const newBoardData = {
-                title: "New Travel Mood Board",
-                description: "Start creating your travel inspiration board",
-                themes: ["Travel", "Adventure"],
-                activities: ["Sightseeing", "Photography"],
-                colorPalette: ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe']
-            };
-
-            const response = await moodBoardService.createMoodBoard(newBoardData);
-            if (response.success) {
-                const newBoard = response.data;
-                setCurrentBoard(newBoard);
-                setBoards(prev => [newBoard, ...prev]);
-                setIsOpen(true);
-                toast.success('New mood board created!');
-            }
-        } catch (error) {
-            console.error('Error creating board:', error);
-            toast.error('Failed to create new board');
-        }
-    };
-
-    const openBoard = (board) => {
-        console.log('openBoard called with board:', board);
-        setCurrentBoard(board);
-        setSelectedBoard(board);
+      const response = await moodBoardService.createMoodBoard(newBoardData);
+      if (response.success) {
+        const newBoard = response.data;
+        setCurrentBoard(newBoard);
+        setBoards(prev => [newBoard, ...prev]);
         setIsOpen(true);
-        console.log('Board opened, currentBoard set to:', board);
-    };
-
-    const toggleCollaboration = () => {
-        setIsCollaborating(!isCollaborating);
-    };
-
-    const handleSaveBoard = async () => {
-        if (currentBoard && currentBoard._id) {
-            try {
-                const updateData = {
-                    title: currentBoard.title,
-                    description: currentBoard.description,
-                    elements: currentBoard.elements,
-                    settings: currentBoard.settings,
-                    metadata: currentBoard.metadata
-                };
-
-                const response = await moodBoardService.updateMoodBoard(currentBoard._id, updateData);
-                if (response.success) {
-                    setCurrentBoard(response.data);
-                    setBoards(prev =>
-                        prev.map(board =>
-                            board._id === currentBoard._id ? response.data : board
-                        )
-                    );
-                    toast.success("Mood board saved successfully!");
-                }
-            } catch (error) {
-                console.error('Error saving board:', error);
-                toast.error('Failed to save mood board');
-            }
-        }
-    };
-
-    const handleShareBoard = async () => {
-        if (currentBoard) {
-            try {
-                const shareUrl = `${window.location.origin}/moodboard/${currentBoard._id}`;
-                await navigator.clipboard.writeText(shareUrl);
-                toast.success("Share link copied to clipboard!");
-            } catch (error) {
-                console.error('Error copying to clipboard:', error);
-                toast.error('Failed to copy share link');
-            }
-        }
-    };
-
-    const handleDeleteBoard = async (boardId) => {
-        if (window.confirm('Are you sure you want to delete this board? This action cannot be undone.')) {
-            try {
-                const response = await moodBoardService.deleteMoodBoard(boardId);
-                if (response.success) {
-                    setBoards(prev => prev.filter(board => board._id !== boardId));
-                    if (currentBoard?._id === boardId) {
-                        setIsOpen(false);
-                        setCurrentBoard(null);
-                    }
-                    toast.success('Mood board deleted successfully');
-                }
-            } catch (error) {
-                console.error('Error deleting board:', error);
-                toast.error('Failed to delete mood board');
-            }
-        }
-    };
-
-    const handleAddCollaborator = async (email, role = 'viewer') => {
-        if (!currentBoard?._id) return;
-
-        try {
-            const response = await moodBoardService.addCollaborator(currentBoard._id, { email, role });
-            if (response.success) {
-                setCurrentBoard(response.data);
-                setCollaborators(response.data.collaborators);
-                setMessages(response.data.messages);
-                toast.success(`Invitation sent to ${email}`);
-            }
-        } catch (error) {
-            console.error('Error adding collaborator:', error);
-            toast.error('Failed to add collaborator');
-        }
-    };
-
-    const handleAddMessage = async (text) => {
-        if (!currentBoard?._id || !text.trim()) return;
-
-        try {
-            const response = await moodBoardService.addMessage(currentBoard._id, { text });
-            if (response.success) {
-                setMessages(response.data.messages);
-            }
-        } catch (error) {
-            console.error('Error adding message:', error);
-            toast.error('Failed to send message');
-        }
-    };
-
-    const handleExportBoard = async (format = 'png', quality = 90) => {
-        if (!currentBoard?._id) return;
-
-        try {
-            const response = await moodBoardService.exportMoodBoard(currentBoard._id, format, quality);
-            if (response.success) {
-                // Handle download
-                const link = document.createElement('a');
-                link.href = response.data.downloadUrl;
-                link.download = `${currentBoard.title || 'moodboard'}.${format}`;
-                link.click();
-                toast.success('Board exported successfully!');
-            }
-        } catch (error) {
-            console.error('Error exporting board:', error);
-            toast.error('Failed to export board');
-        }
-    };
-
-    // Show loading state while auth is being determined
-    if (isAuthenticated === undefined) {
-        return (
-            <div className="flex items-center justify-center min-h-[400px]">
-                <div className="text-center">
-                    <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-600 mx-auto mb-4"></div>
-                    <p className="text-gray-500">Loading...</p>
-                </div>
-            </div>
-        );
+        toast.success('New mood board created!');
+      }
+    } catch (error) {
+      console.error('Error creating board:', error);
+      toast.error('Failed to create new board');
     }
+  };
 
-    if (!isAuthenticated) {
-        return (
-            <div className="flex items-center justify-center min-h-[400px]">
-                <div className="text-center">
-                    <Palette className="w-16 h-16 mx-auto mb-4 text-gray-400" />
-                    <h3 className="text-xl font-semibold mb-2">Sign in to create mood boards</h3>
-                    <p className="text-gray-500">Create beautiful travel inspiration boards with AI</p>
-                </div>
-            </div>
-        );
+  const openBoard = (board) => {
+    console.log('openBoard called with board:', board);
+    setCurrentBoard(board);
+    setSelectedBoard(board);
+    setIsOpen(true);
+    console.log('Board opened, currentBoard set to:', board);
+  };
+
+  const toggleCollaboration = () => {
+    setIsCollaborating(!isCollaborating);
+  };
+
+  const handleSaveBoard = async () => {
+    if (currentBoard && currentBoard._id) {
+      try {
+        const updateData = {
+          title: currentBoard.title,
+          description: currentBoard.description,
+          elements: currentBoard.elements,
+          settings: currentBoard.settings,
+          metadata: currentBoard.metadata
+        };
+
+        const response = await moodBoardService.updateMoodBoard(currentBoard._id, updateData);
+        if (response.success) {
+          setCurrentBoard(response.data);
+          setBoards(prev =>
+            prev.map(board =>
+              board._id === currentBoard._id ? response.data : board
+            )
+          );
+          toast.success("Mood board saved successfully!");
+        }
+      } catch (error) {
+        console.error('Error saving board:', error);
+        toast.error('Failed to save mood board');
+      }
     }
+  };
 
+  const handleShareBoard = async () => {
+    if (currentBoard) {
+      try {
+        const shareUrl = `${window.location.origin}/moodboard/${currentBoard._id}`;
+        await navigator.clipboard.writeText(shareUrl);
+        toast.success("Share link copied to clipboard!");
+      } catch (error) {
+        console.error('Error copying to clipboard:', error);
+        toast.error('Failed to copy share link');
+      }
+    }
+  };
+
+  const handleDeleteBoard = async (boardId) => {
+    if (window.confirm('Are you sure you want to delete this board? This action cannot be undone.')) {
+      try {
+        const response = await moodBoardService.deleteMoodBoard(boardId);
+        if (response.success) {
+          setBoards(prev => prev.filter(board => board._id !== boardId));
+          if (currentBoard?._id === boardId) {
+            setIsOpen(false);
+            setCurrentBoard(null);
+          }
+          toast.success('Mood board deleted successfully');
+        }
+      } catch (error) {
+        console.error('Error deleting board:', error);
+        toast.error('Failed to delete mood board');
+      }
+    }
+  };
+
+  const handleAddCollaborator = async (email, role = 'viewer') => {
+    if (!currentBoard?._id) return;
+
+    try {
+      const response = await moodBoardService.addCollaborator(currentBoard._id, { email, role });
+      if (response.success) {
+        setCurrentBoard(response.data);
+        setCollaborators(response.data.collaborators);
+        setMessages(response.data.messages);
+        toast.success(`Invitation sent to ${email}`);
+      }
+    } catch (error) {
+      console.error('Error adding collaborator:', error);
+      toast.error('Failed to add collaborator');
+    }
+  };
+
+  const handleAddMessage = async (text) => {
+    if (!currentBoard?._id || !text.trim()) return;
+
+    try {
+      const response = await moodBoardService.addMessage(currentBoard._id, { text });
+      if (response.success) {
+        setMessages(response.data.messages);
+      }
+    } catch (error) {
+      console.error('Error adding message:', error);
+      toast.error('Failed to send message');
+    }
+  };
+
+  const handleExportBoard = async (format = 'png', quality = 90) => {
+    if (!currentBoard?._id) return;
+
+    try {
+      const response = await moodBoardService.exportMoodBoard(currentBoard._id, format, quality);
+      if (response.success) {
+        // Handle download
+        const link = document.createElement('a');
+        link.href = response.data.downloadUrl;
+        link.download = `${currentBoard.title || 'moodboard'}.${format}`;
+        link.click();
+        toast.success('Board exported successfully!');
+      }
+    } catch (error) {
+      console.error('Error exporting board:', error);
+      toast.error('Failed to export board');
+    }
+  };
+
+  // Show loading state while auth is being determined
+  if (isAuthenticated === undefined) {
     return (
-        <div className="mood-board-container">
-            {/* Main Dashboard View */}
-            {!isOpen && (
-                <div className="mood-board-dashboard">
-                    <div className="dashboard-header">
-                        <div className="header-content">
-                            <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
-                                Travel Mood Boards
-                            </h1>
-                            <p className="text-lg text-gray-600 dark:text-gray-300 mt-2">
-                                Create, collaborate, and get inspired with AI-powered travel planning
-                            </p>
-                        </div>
-                        <motion.button
-                            whileHover={{ scale: 1.05 }}
-                            whileTap={{ scale: 0.95 }}
-                            onClick={createNewBoard}
-                            className="create-board-btn"
-                            disabled={isLoading}
-                        >
-                            <Plus className="w-5 h-5 mr-2" />
-                            {isLoading ? 'Creating...' : 'Create New Board'}
-                        </motion.button>
-                    </div>
-
-                    {/* AI Generator Section */}
-                    <div className="ai-generator-section">
-                        <motion.button
-                            whileHover={{ scale: 1.02 }}
-                            onClick={() => setShowAIGenerator(true)}
-                            className="ai-generator-btn"
-                        >
-                            <Sparkles className="w-5 h-5 mr-2" />
-                            Generate with AI
-                        </motion.button>
-                    </div>
-
-                    {/* Existing Boards Grid */}
-                    <div className="boards-grid">
-                        {isLoading ? (
-                            <div className="text-center py-12">
-                                <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-600 mx-auto mb-4"></div>
-                                <p className="text-gray-500">Loading your mood boards...</p>
-                            </div>
-                        ) : !boards || boards.length === 0 ? (
-                            <div className="text-center py-12">
-                                <Palette className="w-16 h-16 mx-auto mb-4 text-gray-400" />
-                                <h3 className="text-xl font-semibold mb-2">No mood boards yet</h3>
-                                <p className="text-gray-500">Create your first travel mood board to get started!</p>
-                            </div>
-                        ) : (
-                            boards.map((board) => (
-                                <motion.div
-                                    key={board._id || board.id}
-                                    whileHover={{ y: -5, scale: 1.02 }}
-                                    whileTap={{ scale: 0.98 }}
-                                    onClick={() => openBoard(board)}
-                                    className="board-card"
-                                >
-                                    <div className="board-thumbnail">
-                                        <img src={board.elements?.[0]?.imageUrl || 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop'} alt={board.title} loading="lazy"  />
-                                        <div className="board-overlay">
-                                            <div className="overlay-actions">
-                                                <button className="action-btn">
-                                                    <Eye className="w-4 h-4" />
-                                                </button>
-                                                <button className="action-btn">
-                                                    <Share2 className="w-4 h-4" />
-                                                </button>
-                                                <button className="action-btn">
-                                                    <Heart className="w-4 h-4" />
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div className="board-info">
-                                        <h3 className="board-title">{board.title}</h3>
-                                        <div className="board-meta">
-                                            <span className="board-theme">{board.themes?.[0] || 'Travel'}</span>
-                                            <span className="board-collaborators">
-                                                <Users className="w-4 h-4 mr-1" />
-                                                {board.collaborators?.length || 1}
-                                            </span>
-                                        </div>
-                                        <p className="board-date">
-                                            {board.updatedAt
-                                                ? new Date(board.updatedAt).toLocaleDateString()
-                                                : board.createdAt
-                                                    ? new Date(board.createdAt).toLocaleDateString()
-                                                    : 'Recently'
-                                            }
-                                        </p>
-                                    </div>
-                                </motion.div>
-                            ))
-                        )}
-                    </div>
-                </div>
-            )}
-
-            {/* Mood Board Editor */}
-            <AnimatePresence>
-                {isOpen && currentBoard && (
-                    <motion.div
-                        initial={{ opacity: 0, x: '100%' }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{ opacity: 0, x: '100%' }}
-                        className="mood-board-editor"
-                    >
-                        {/* Editor Header */}
-                        <div className="editor-header">
-                            <div className="header-left">
-                                <button
-                                    onClick={() => setIsOpen(false)}
-                                    className="back-btn"
-                                >
-                                    ← Back to Dashboard
-                                </button>
-                                <input
-                                    type="text"
-                                    value={currentBoard?.title || ''}
-                                    onChange={(e) => setCurrentBoard({
-                                        ...currentBoard,
-                                        title: e.target.value
-                                    })}
-                                    className="board-title-input"
-                                />
-                            </div>
-                            <div className="header-actions">
-                                <motion.button
-                                    whileHover={{ scale: 1.05 }}
-                                    whileTap={{ scale: 0.95 }}
-                                    onClick={toggleCollaboration}
-                                    className={`collab-btn ${isCollaborating ? 'active' : ''}`}
-                                >
-                                    <Users className="w-4 h-4 mr-2" />
-                                    {isCollaborating ? 'Collaborating' : 'Collaborate'}
-                                </motion.button>
-                                <motion.button
-                                    whileHover={{ scale: 1.05 }}
-                                    whileTap={{ scale: 0.95 }}
-                                    onClick={handleShareBoard}
-                                    className="share-btn"
-                                >
-                                    <Share2 className="w-4 h-4 mr-2" />
-                                    Share
-                                </motion.button>
-                                <motion.button
-                                    whileHover={{ scale: 1.05 }}
-                                    whileTap={{ scale: 0.95 }}
-                                    onClick={handleSaveBoard}
-                                    className="save-btn"
-                                >
-                                    Save
-                                </motion.button>
-                            </div>
-                        </div>
-
-                        {/* Main Editor Content */}
-                        <div className="editor-content">
-                            {/* Left Sidebar */}
-                            <MoodBoardSidebar
-                                ref={sidebarRef}
-                                currentBoard={currentBoard}
-                                setCurrentBoard={setCurrentBoard}
-                                boards={boards}
-                                selectedElement={selectedElement}
-                                setSelectedElement={setSelectedElement}
-                                onAIGenerate={() => setShowAIGenerator(true)}
-                                onSave={handleSaveBoard}
-                                onExport={handleExportBoard}
-                                onShare={handleShareBoard}
-                                onCollaborate={toggleCollaboration}
-                                isCollaborating={isCollaborating}
-                                collaborators={collaborators}
-                                onToggleCollaboration={toggleCollaboration}
-                                onOpenBoard={openBoard}
-                                onNewBoard={createNewBoard}
-                                onDeleteBoard={handleDeleteBoard}
-                            />
-
-                            {/* Main Canvas */}
-                            <div className="canvas-container">
-                                <MoodBoardCanvas
-                                    board={currentBoard}
-                                    setBoard={setCurrentBoard}
-                                    isCollaborating={isCollaborating}
-                                    selectedElement={selectedElement}
-                                    setSelectedElement={setSelectedElement}
-                                />
-                            </div>
-
-                            {/* Right Collaboration Panel */}
-                            {isCollaborating && (
-                                <CollaborationPanel
-                                    board={currentBoard}
-                                    collaborators={collaborators}
-                                    setCollaborators={setCollaborators}
-                                    messages={messages}
-                                    setMessages={setMessages}
-                                    onAddMessage={handleAddMessage}
-                                    onAddCollaborator={handleAddCollaborator}
-                                    isOpen={isCollaborating}
-                                    onClose={() => setIsCollaborating(false)}
-                                />
-                            )}
-                        </div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-
-            {/* AI Generator Modal */}
-            <AnimatePresence>
-                {showAIGenerator && (
-                    <AIGenerator
-                        onClose={() => setShowAIGenerator(false)}
-                        onGenerate={async (generatedBoard) => {
-                            try {
-                                // Save the AI-generated board to backend
-                                const response = await moodBoardService.createMoodBoard(generatedBoard);
-                                if (response.success) {
-                                    const savedBoard = response.data;
-                                    setCurrentBoard(savedBoard);
-                                    setBoards(prev => [savedBoard, ...prev]);
-                                    setShowAIGenerator(false);
-                                    setIsOpen(true);
-                                    toast.success('AI-generated board created successfully!');
-                                }
-                            } catch (error) {
-                                console.error('Error saving AI-generated board:', error);
-                                toast.error('Failed to save AI-generated board');
-                            }
-                        }}
-                    />
-                )}
-            </AnimatePresence>
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-600 mx-auto mb-4"></div>
+          <p className="text-gray-500">Loading...</p>
         </div>
+      </div>
     );
+  }
+
+  // 🔹 Improved unauthenticated empty state
+  if (!isAuthenticated) {
+    return (
+      <section className="mb-empty-wrap">
+        <div className="mb-empty-card">
+          <Palette className="mb-icon" />
+          <h2 className="mb-title">Create Your Travel Mood Board</h2>
+          <p className="mb-subtitle">
+            Save destinations, inspirations, and packages all in one place.
+          </p>
+          <div className="mb-ctas">
+            <button
+              className="mb-btn-primary"
+              onClick={() => navigate('/login?redirect=/moodboard')}
+            >
+              Sign in to Start
+            </button>
+            <button
+              className="mb-btn-secondary"
+              onClick={() => navigate('/discover')}
+            >
+              Explore ideas
+            </button>
+          </div>
+          <ul className="mb-hints">
+            <li>• Save destinations</li>
+            <li>• Collect inspirations</li>
+            <li>• Share with friends</li>
+          </ul>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <div className="mood-board-container">
+      {/* Main Dashboard View */}
+      {!isOpen && (
+        <div className="mood-board-dashboard">
+          <div className="dashboard-header">
+            <div className="header-content">
+              <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+                Travel Mood Boards
+              </h1>
+              <p className="text-lg text-gray-600 dark:text-gray-300 mt-2">
+                Create, collaborate, and get inspired with AI-powered travel planning
+              </p>
+            </div>
+            <motion.button
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              onClick={createNewBoard}
+              className="create-board-btn"
+              disabled={isLoading}
+            >
+              <Plus className="w-5 h-5 mr-2" />
+              {isLoading ? 'Creating...' : 'Create New Board'}
+            </motion.button>
+          </div>
+
+          {/* AI Generator Section */}
+          <div className="ai-generator-section">
+            <motion.button
+              whileHover={{ scale: 1.02 }}
+              onClick={() => setShowAIGenerator(true)}
+              className="ai-generator-btn"
+            >
+              <Sparkles className="w-5 h-5 mr-2" />
+              Generate with AI
+            </motion.button>
+          </div>
+
+          {/* Existing Boards Grid */}
+          <div className="boards-grid">
+            {isLoading ? (
+              <div className="text-center py-12">
+                <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-600 mx-auto mb-4"></div>
+                <p className="text-gray-500">Loading your mood boards...</p>
+              </div>
+            ) : !boards || boards.length === 0 ? (
+              // 🔹 Improved "no boards yet" state
+              <div className="mb-empty-card slim">
+                <Palette className="mb-icon" />
+                <h3 className="mb-title">No mood boards yet</h3>
+                <p className="mb-subtitle">Create your first board to get started.</p>
+                <button
+                  className="mb-btn-primary"
+                  onClick={createNewBoard}
+                  disabled={isLoading}
+                >
+                  {isLoading ? 'Creating...' : 'Create New Board'}
+                </button>
+              </div>
+            ) : (
+              boards.map((board) => (
+                <motion.div
+                  key={board._id || board.id}
+                  whileHover={{ y: -5, scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  onClick={() => openBoard(board)}
+                  className="board-card"
+                >
+                  <div className="board-thumbnail">
+                    <img
+                      src={
+                        board.elements?.[0]?.imageUrl ||
+                        'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop'
+                      }
+                      alt={board.title}
+                      loading="lazy"
+                    />
+                    <div className="board-overlay">
+                      <div className="overlay-actions">
+                        <button className="action-btn">
+                          <Eye className="w-4 h-4" />
+                        </button>
+                        <button className="action-btn">
+                          <Share2 className="w-4 h-4" />
+                        </button>
+                        <button className="action-btn">
+                          <Heart className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="board-info">
+                    <h3 className="board-title">{board.title}</h3>
+                    <div className="board-meta">
+                      <span className="board-theme">{board.themes?.[0] || 'Travel'}</span>
+                      <span className="board-collaborators">
+                        <Users className="w-4 h-4 mr-1" />
+                        {board.collaborators?.length || 1}
+                      </span>
+                    </div>
+                    <p className="board-date">
+                      {board.updatedAt
+                        ? new Date(board.updatedAt).toLocaleDateString()
+                        : board.createdAt
+                        ? new Date(board.createdAt).toLocaleDateString()
+                        : 'Recently'}
+                    </p>
+                  </div>
+                </motion.div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Mood Board Editor */}
+      <AnimatePresence>
+        {isOpen && currentBoard && (
+          <motion.div
+            initial={{ opacity: 0, x: '100%' }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: '100%' }}
+            className="mood-board-editor"
+          >
+            {/* Editor Header */}
+            <div className="editor-header">
+              <div className="header-left">
+                <button
+                  onClick={() => setIsOpen(false)}
+                  className="back-btn"
+                >
+                  ← Back to Dashboard
+                </button>
+                <input
+                  type="text"
+                  value={currentBoard?.title || ''}
+                  onChange={(e) =>
+                    setCurrentBoard({
+                      ...currentBoard,
+                      title: e.target.value
+                    })
+                  }
+                  className="board-title-input"
+                />
+              </div>
+              <div className="header-actions">
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={toggleCollaboration}
+                  className={`collab-btn ${isCollaborating ? 'active' : ''}`}
+                >
+                  <Users className="w-4 h-4 mr-2" />
+                  {isCollaborating ? 'Collaborating' : 'Collaborate'}
+                </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={handleShareBoard}
+                  className="share-btn"
+                >
+                  <Share2 className="w-4 h-4 mr-2" />
+                  Share
+                </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={handleSaveBoard}
+                  className="save-btn"
+                >
+                  Save
+                </motion.button>
+              </div>
+            </div>
+
+            {/* Main Editor Content */}
+            <div className="editor-content">
+              {/* Left Sidebar */}
+              <MoodBoardSidebar
+                ref={sidebarRef}
+                currentBoard={currentBoard}
+                setCurrentBoard={setCurrentBoard}
+                boards={boards}
+                selectedElement={selectedElement}
+                setSelectedElement={setSelectedElement}
+                onAIGenerate={() => setShowAIGenerator(true)}
+                onSave={handleSaveBoard}
+                onExport={handleExportBoard}
+                onShare={handleShareBoard}
+                onCollaborate={toggleCollaboration}
+                isCollaborating={isCollaborating}
+                collaborators={collaborators}
+                onToggleCollaboration={toggleCollaboration}
+                onOpenBoard={openBoard}
+                onNewBoard={createNewBoard}
+                onDeleteBoard={handleDeleteBoard}
+              />
+
+              {/* Main Canvas */}
+              <div className="canvas-container">
+                <MoodBoardCanvas
+                  board={currentBoard}
+                  setBoard={setCurrentBoard}
+                  isCollaborating={isCollaborating}
+                  selectedElement={selectedElement}
+                  setSelectedElement={setSelectedElement}
+                />
+              </div>
+
+              {/* Right Collaboration Panel */}
+              {isCollaborating && (
+                <CollaborationPanel
+                  board={currentBoard}
+                  collaborators={collaborators}
+                  setCollaborators={setCollaborators}
+                  messages={messages}
+                  setMessages={setMessages}
+                  onAddMessage={handleAddMessage}
+                  onAddCollaborator={handleAddCollaborator}
+                  isOpen={isCollaborating}
+                  onClose={() => setIsCollaborating(false)}
+                />
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* AI Generator Modal */}
+      <AnimatePresence>
+        {showAIGenerator && (
+          <AIGenerator
+            onClose={() => setShowAIGenerator(false)}
+            onGenerate={async (generatedBoard) => {
+              try {
+                // Save the AI-generated board to backend
+                const response = await moodBoardService.createMoodBoard(generatedBoard);
+                if (response.success) {
+                  const savedBoard = response.data;
+                  setCurrentBoard(savedBoard);
+                  setBoards(prev => [savedBoard, ...prev]);
+                  setShowAIGenerator(false);
+                  setIsOpen(true);
+                  toast.success('AI-generated board created successfully!');
+                }
+              } catch (error) {
+                console.error('Error saving AI-generated board:', error);
+                toast.error('Failed to save AI-generated board');
+              }
+            }}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
 };
 
 export default MoodBoard;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -52,7 +52,7 @@ import LeaderBoard from './components/Leaderboard/LeaderBoard';
 const Home = lazy(() => import('./pages/Home'));
 const About = lazy(() => import('./pages/About'));
 const Blog = lazy(() => import('./pages/Blog'));
-const Discover = lazy(() => import('./pages/Discover'));
+import DiscoverSection from "./components/Home/DiscoverSection";
 const Trips = lazy(() => import('./pages/Trips'));
 const Review = lazy(() => import('./pages/Review'));
 const Contributors = lazy(() => import('./pages/Contributors'));
@@ -112,7 +112,7 @@ const router = createBrowserRouter([
       { path: '/', element: <Suspense fallback={<Spinner />}><Home /></Suspense> },
       { path: '/about', element: <Suspense fallback={<Spinner />}><About /></Suspense> },
       { path: '/blog', element: <Suspense fallback={<Spinner />}><Blog /></Suspense> },
-      { path: '/discover', element: <Suspense fallback={<Spinner />}><Discover /></Suspense> },
+      { path: '/discover', element: <DiscoverSection /> },
       { path: '/currency-converter', element: <Suspense fallback={<Spinner />}><CurrencyConverter /></Suspense> },
       { path: '/enhanced-currency', element: <Suspense fallback={<Spinner />}><EnhancedCurrencyConverter /></Suspense> },
       { path: '/trips', element: <Suspense fallback={<Spinner />}><Trips /></Suspense> },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -183,10 +183,10 @@
   resolved "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz"
   integrity sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==
 
-"@esbuild/linux-x64@0.25.9":
+"@esbuild/win32-x64@0.25.9":
   version "0.25.9"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz"
-  integrity sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz"
+  integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.7.0"
@@ -571,10 +571,10 @@
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz"
   integrity sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==
 
-"@rollup/rollup-linux-x64-gnu@4.50.0":
+"@rollup/rollup-win32-x64-msvc@4.50.0":
   version "4.50.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz"
-  integrity sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==
+  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz"
+  integrity sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==
 
 "@standard-schema/spec@^1.0.0":
   version "1.0.0"
@@ -606,10 +606,10 @@
     source-map-js "^1.2.1"
     tailwindcss "4.1.12"
 
-"@tailwindcss/oxide-linux-x64-gnu@4.1.12":
+"@tailwindcss/oxide-win32-x64-msvc@4.1.12":
   version "4.1.12"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.12.tgz"
-  integrity sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.12.tgz"
+  integrity sha512-NKIh5rzw6CpEodv/++r0hGLlfgT/gFN+5WNdZtvh6wpU2BpGNgdjvj6H2oFc8nCM839QM1YOhjpgbAONUb4IxA==
 
 "@tailwindcss/oxide@4.1.12":
   version "4.1.12"
@@ -1908,10 +1908,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lightningcss-linux-x64-gnu@1.30.1:
+lightningcss-win32-x64-msvc@1.30.1:
   version "1.30.1"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz"
-  integrity sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==
+  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz"
+  integrity sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==
 
 lightningcss@^1.21.0, lightningcss@1.30.1:
   version "1.30.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "TravelGrid",
+  "name": "TravelGrid-GA",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
**## What & Why**

This PR fixes the broken/blank **Mood Boards** section on the Home page.
When a user is **not signed in**, the section used to show a large empty maroon block with only
“Sign in to create mood boards,” which felt unfinished and reduced trust.

**This change:**
- Adds a friendly, polished **empty state card** (icon, heading, subtext, CTAs).
- Wires **“Explore ideas”** CTA to the existing `/discover` route.
- Ensures the Discover page mounts the **DiscoverSection** so it actually renders content.

Closes #1141.

---

**## Changes (files)**

- `client/src/components/MoodBoard/MoodBoard.jsx`
  - Empty state redesigned with heading/subtext/buttons.
  - “Explore ideas” → `navigate('/discover')`.
- `client/src/components/MoodBoard/MoodBoard.css`
  - Styles for the new empty state + small visual polish.
- `client/src/main.jsx`
  - Ensures `/discover` renders the `DiscoverSection` component (no new page file).

---

**## Before**

- Huge empty maroon block with a single line of text.
- “Explore” didn’t lead to useful content.
<img width="960" height="540" alt="{381ECE16-C284-460C-A573-4D43C088192C}" src="https://github.com/user-attachments/assets/83316660-b34c-4d1c-a82e-ec73219740cd" />

**## After**

- Compact, centered empty state card with:
  - **Heading:** “Create Your Travel Mood Board”
  - **Subtext:** “Save destinations, inspirations, and packages all in one place.”
  - **CTAs:**  
    - **Sign in to Start** → login/signup  
    - **Explore ideas** → `/discover`
- `/discover` reliably shows the Discover section.
<img width="960" height="540" alt="{0F02974F-DE96-4053-90F5-7A4E417A6058}" src="https://github.com/user-attachments/assets/42daa06a-308a-4a6f-a1cf-664b34867b6a" />

---

**## How to Test**

1. Run the client and open Home while **logged out**.
2. Scroll to **Mood Boards** section.
   - You should see the new empty state card (icon + copy + two buttons).
3. Click **Explore ideas** → you should be routed to `/discover` and see the Discover cards.
4. Click **Sign in to Start** → routes to login/signup as in your auth flow.

**## Notes**

- No backend changes.
- No breaking changes for authenticated users; normal mood board behaviour is untouched.
- Keeps copy/design consistent with other polished homepage sections.

---

**## Checklist**

- [x] Fixes #1141
- [x] Friendly, accessible empty state (keyboard & screen-reader safe)
- [x] “Explore ideas” → `/discover`
- [x] Minimal changes, reusing existing components/routes
- [x] Lint/build pass locally
---