### PR TITLE
Enhance Navbar dropdown arrow and text color

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -161,15 +161,16 @@ const Navbar = () => {
                 <div className="relative group" key={link.name}>
                   <button
                     aria-label={link.name}
-                    className={`py-1.5 px-2 text-sm font-medium rounded-sm transition-all  duration-300 flex items-center gap-1 truncate max-w-fit ${
+                    className={`py-1.5 px-2 text-sm font-medium rounded-sm transition-all  duration-300 flex items-center gap-1 truncate max-w-fit cursor-pointer ${
                       activeParentTab === link.name
                         ? "bg-gradient-to-r from-pink-700 to-pink-500 shadow-md text-white"
                         : `hover:text-pink-500 hover:shadow-sm ${
                             isDarkMode ? "text-gray-200" : "text-gray-900"
                           }`
                     }`}
-                  >
-                    {link.name} <ChevronDown className="text-neutral-300 w-3.5 h-3.5" />
+                  >  
+                  {/* Chevron rotate on hover */}
+                    {link.name} <ChevronDown className={`w-4 h-4 transform transition-transform duration-400 group-hover:rotate-180  font-bold ${activeParentTab===link.name? "text-white": 'text-gray-900'}`} />
                   </button>
                   {/* Dropdown menu */}
                   <div


### PR DESCRIPTION
**Title:**  
Enhance navbar dropdown arrow and text color

## Description
This PR improves the Navbar dropdown behavior and visibility:  
- Rotates the dropdown arrow (chevron) to indicate open/close state.  
- Updates the dropdown arrow (chevron) text color in light mode for better contrast.  
- Adds smooth slide and fade animation for dropdown menu items. 
- Add cursor pointer to clickable button.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors


## Related Issues
Closes #1186  

## Screenshots (if applicable)

<img width="1920" height="1078" alt="navbar_dropdown_arrow" src="https://github.com/user-attachments/assets/f73fd72f-0a1c-463d-add8-ca8d40bb60c9" />


## Additional Notes
N/A
