### PR TITLE
FOOTER EXTRA SPACE REMOVED

### DIFF
--- a/client/src/components/Custom/Footer.jsx
+++ b/client/src/components/Custom/Footer.jsx
@@ -299,6 +299,7 @@ const Footer = () => {
           </div>
         </div>
       </footer>
+      {/* The extra space has been removed and the footer looks fine */}
 
       {/* Toast Notification */}
       {toast.show && (


### PR DESCRIPTION
**Title:**  
The footer extra space has been removed and looks fine as checked on the local machine and tested it.

## Description
The extra space the came under the footer has been removed from the website. Solved the issue #1232 Footer with Extra space.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors


## Related Issues
Fixes #1232 

## Screenshots (if applicable)
<img width="1902" height="665" alt="image" src="https://github.com/user-attachments/assets/3fa11c3c-8dc0-412a-8218-34e85e25f18c" />
The space has been removed

## Additional Notes
Loved to work on this issue. @gssoc25