### PR TITLE
Guides search fixed

### DIFF
--- a/client/src/pages/TravelGuidesProfiles.jsx
+++ b/client/src/pages/TravelGuidesProfiles.jsx
@@ -109,6 +109,9 @@ const guides = [
   },
 ];
 
+const allGuides = [...guides, ...guides1];
+
+
 const TravelGuidesCarousel = () => {
   const { isDarkMode } = useTheme();
   const location = useLocation();
@@ -145,16 +148,18 @@ const TravelGuidesCarousel = () => {
       return;
     }
 
+    
+
     setIsSearching(true);
-    const filteredGuides = guides.filter(
-      (guide) =>
-        guide.name.toLowerCase().includes(query.toLowerCase()) ||
-        guide.expertise.toLowerCase().includes(query.toLowerCase()) ||
-        guide.bio.toLowerCase().includes(query.toLowerCase()) ||
-        guide.details.location.toLowerCase().includes(query.toLowerCase()) ||
-        guide.details.languages.toLowerCase().includes(query.toLowerCase())
-    );
-    setSearchResults(filteredGuides);
+    const filteredGuides = allGuides.filter(
+  (guide) =>
+    guide.name.toLowerCase().includes(query.toLowerCase()) ||
+    guide.expertise.toLowerCase().includes(query.toLowerCase()) ||
+    guide.bio.toLowerCase().includes(query.toLowerCase()) ||
+    guide.details.location.toLowerCase().includes(query.toLowerCase()) ||
+    guide.details.languages.toLowerCase().includes(query.toLowerCase())
+);
+setSearchResults(filteredGuides);
   };
 
   const clearSearch = () => {


### PR DESCRIPTION
Title:
Fix: Search includes all guides from both arrays (pet and non-pet) in TravelGuidesCarousel

Description
Previously, searching for guides only checked the guides array, so guides present in the guides1 array were never found (e.g., "Aarav Mehta" would not show up).
This change combines both guides and guides1 into a single array for search, ensuring all guides are returned when searching by name, expertise, location, or language.

Type of Change
 ✅Bug fix
 New feature
 Refactor
 Documentation update
 Other (please describe):

Checklist
 ✅My code follows the project style guidelines
 ✅I have performed a self-review of my code
 ✅I have commented my code, particularly in hard-to-understand areas
 ✅ My changes generate no new warnings or errors

Related Issues
https://github.com/Adarsh-Chaubey03/TravelGrid/issues/1250

Screenshots (if applicable)
<img width="1906" height="996" alt="Screenshot 2025-09-22 165945" src="https://github.com/user-attachments/assets/86fafdab-9f76-4e5d-b38f-bb1cd7cc4079" />


Additional Notes
Searched guides (like "Aarav Mehta") are now correctly found regardless of the array in which they are defined. Search results are accurate and user experience is improved.