### PR TITLE
Fix: remove overriding background color in Contact 

### DIFF
--- a/client/src/components/Contact.jsx
+++ b/client/src/components/Contact.jsx
@@ -53,10 +53,7 @@ const Contact = () => {
   ];
 
   return (
-    <div className={`min-h-screen ${isDarkMode
-      ? 'bg-gradient-to-br from-black to-pink-700'
-      : 'bg-gradient-to-br from-rose-50 to-gray-100'
-      }`}>
+    <div className="min-h-screen">
       <Navbar />
       {/* Hero Section */}
       <div className={`py-24 px-4 relative overflow-hidden ${isDarkMode


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #1309 

## 🎯 Rationale

This PR update removes the manually set background color in the contact section that was overriding the site’s theme color

## 📝 Summary of Changes

- Removed contact section background color that conflicted with the theme.
- No other functional or styling changes.


## 🎨 User-Facing Changes

<!--
Describe any changes that affect end users:
- New features or functionality
- UI/UX modifications
- API changes
- Configuration changes
- Deprecations
-->

### Frontend Changes
- [ ] UI components modified
- [ ] New user interactions added
- [x] Styling/theme changes

### Backend/API Changes
- [ ] New endpoints added
- [ ] Existing endpoints modified
- [ ] Response format changes

## 📋 Checklist

<!--
Complete this checklist before requesting review:
-->

### Code Quality
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console.log or debug statements left
- [x] Error handling implemented appropriately

### Review Readiness  
- [x] PR title is descriptive and follows conventions
- [x] PR description is complete and accurate
- [x] Commits are atomic and well-documented
- [x] Branch is up to date with target branch



## 📸 Screenshots/Demo

<img width="1770" height="734" alt="contact_bg" src="https://github.com/user-attachments/assets/49c281b3-d0dd-4712-a095-9f927e276987" />

## Additional Context 
There are currently two contact pages in the repository.  extra contact page be removed, keeping only the **Contact.jsx** component linked to the /contact URL.


