### PR TITLE
fixed the footer background in the light mode

### DIFF
--- a/client/src/components/Custom/Footer.jsx
+++ b/client/src/components/Custom/Footer.jsx
@@ -53,7 +53,7 @@ const Footer = () => {
       <footer className={`relative transition-all duration-300 ${
      isDarkMode 
           ? 'bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900' 
-          : 'bg-gradient-to-br from-gray-900  to-pink-200'
+          : 'bg-gradient-to-br from-gray-900  to-pink-900'
       }`}>
         {/* Background pattern */}
         <div className="absolute inset-0 bg-[url('data:image/svg+xml,...')] opacity-20" />


### PR DESCRIPTION
fixes #1358

- footer is matching with the website theme in the light mode

<img width="1876" height="916" alt="image" src="https://github.com/user-attachments/assets/548738b8-31c0-43a7-aa87-c204ffb92ab1" />

