### PR TITLE
Fixed  UI/UX Inconsistency for both light and dark mode on Leaderboard

### DIFF
--- a/client/src/components/Leaderboard/LeaderBoard.jsx
+++ b/client/src/components/Leaderboard/LeaderBoard.jsx
@@ -238,7 +238,11 @@ export default function LeaderBoard() {
   }, [contributors]);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-secondary-900 py-6 sm:py-12 px-2 sm:px-4">
+    <div className={`min-h-screen py-6 sm:py-12 px-2 sm:px-4 ${
+            isDarkMode 
+            ? 'bg-gradient-to-br from-black to-pink-900'
+            : 'from-pink-200/50 via-white/70 to-blue-200/50'}`}>
+              
       <div className="max-w-5xl mx-auto">
         <motion.div
           className="text-center mb-8 sm:mb-12 px-2"


### PR DESCRIPTION
fixes #1366 
<img width="1874" height="916" alt="image" src="https://github.com/user-attachments/assets/56c02fca-110f-44c6-a0e6-cfbde2259c53" />
<img width="1877" height="890" alt="image" src="https://github.com/user-attachments/assets/0d247c81-7da7-41d8-8c9f-0d53f98df3f1" />
