### PR TITLE
Fix: Add margin between the navbar and about page title

### DIFF
--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -204,7 +204,7 @@ function About() {
   ];
 
   return (
-    <div className={`w-full overflow-hidden transition-all duration-300`}>
+    <div className={`w-full overflow-hidden transition-all duration-300 mt-16`}>
       {/* Hero Section */}
       <motion.div
         initial={{ opacity: 0, y: 50 }}


### PR DESCRIPTION
---
name: Pull Request Template
about: "Use this format for all pull requests."
title: ''
labels: 'gssoc25, hacktoberfest, hacktoberfest-accepted'
assignees: ''

---

## 🔗 Related Issue

<!--
Link the related issue using GitHub's linking syntax:
- "Closes #123" - for bug fixes and completed features
-->

- Closes #1408 

## 📝 Summary of Changes
This PR : 
- Added top margin to the About page title section  
- Improved spacing for better visual consistency with other pages  

## 📸 Screenshots/Demo
| Before | After |
|--------|--------|
| <img width="1656" height="752" alt="About" src="https://github.com/user-attachments/assets/9b1f5636-d6fe-4c0c-b9ea-fa7d4fb61ed4" /> | <img width="1737" height="752" alt="about_title" src="https://github.com/user-attachments/assets/44ee6a80-edab-4246-be8f-d04c37b6c2d4" /> |

<!--
For UI changes, include before/after screenshots or demo links:
-->

---

<!-- 
Thank you for contributing! 🎉

Please ensure you've filled out all relevant sections above. 
The maintainers will review your changes and provide feedback as soon as possible.
-->
