### PR TITLE
fix: update ExpenseChart to use high-contrast color palettes and impr…

### DIFF
--- a/client/src/components/TripExpenseCalculator/ExpenseChart.jsx
+++ b/client/src/components/TripExpenseCalculator/ExpenseChart.jsx
@@ -2,30 +2,61 @@
 import React, { memo } from "react";
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
 
-const COLORS = ['#f43f5e', '#fb7185', '#EC4899', '#8B5CF6', '#F472B6', '#EF4444'];
+// High-contrast categorical palettes (inspired by Tableau/Observable palettes)
+const COLORS_LIGHT = [
+  '#1f77b4', // blue
+  '#ff7f0e', // orange
+  '#2ca02c', // green
+  '#d62728', // red
+  '#9467bd', // purple
+  '#17becf', // cyan
+];
+
+const COLORS_DARK = [
+  '#4c78a8', // blue
+  '#f58518', // orange
+  '#54a24b', // green
+  '#e45756', // red
+  '#b279a2', // purple
+  '#72b7b2', // teal
+];
 
 const ExpenseChart = ({ chartData, isDarkMode }) => {
   console.log("ExpenseChart re-rendered 🎯");
   return (
-     <><h3 className={`text-2xl font-bold text-center mb-2 ${isDarkMode ? 'text-white' : 'text-gray-700'}`}>Expense Breakdown</h3><ResponsiveContainer width="100%" height={450}>
-          <PieChart margin={{ top: 30, bottom: 60 }}>
-              <Pie
-                  data={chartData}
-                  dataKey="value"
-                  nameKey="name"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={100}
-                  label
-              >
-                  {chartData.map((_, index) => (
-                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                  ))}
-              </Pie>
-              <Tooltip />
-              <Legend layout="horizontal" verticalAlign="bottom" align="center" />
-          </PieChart>
-      </ResponsiveContainer></>
+     <>
+       <h3 className={`text-2xl font-bold text-center mb-2 ${isDarkMode ? 'text-white' : 'text-gray-700'}`}>Expense Breakdown</h3>
+       <ResponsiveContainer width="100%" height={450}>
+         <PieChart margin={{ top: 30, bottom: 60 }}>
+           <Pie
+             data={chartData}
+             dataKey="value"
+             nameKey="name"
+             cx="50%"
+             cy="50%"
+             outerRadius={110}
+             label
+           >
+             {chartData.map((_, index) => (
+               <Cell
+                 key={`cell-${index}`}
+                 fill={(isDarkMode ? COLORS_DARK : COLORS_LIGHT)[index % (isDarkMode ? COLORS_DARK.length : COLORS_LIGHT.length)]}
+                 stroke={isDarkMode ? '#0f172a' : '#ffffff'}
+                 strokeWidth={2}
+               />
+             ))}
+           </Pie>
+           <Tooltip
+             contentStyle={{
+               background: isDarkMode ? '#0f172a' : '#ffffff',
+               color: isDarkMode ? '#f8fafc' : '#1f2937',
+               border: `1px solid ${isDarkMode ? '#334155' : '#e2e8f0'}`,
+             }}
+           />
+           <Legend layout="horizontal" verticalAlign="bottom" align="center" />
+         </PieChart>
+       </ResponsiveContainer>
+     </>
   );
 };
 


### PR DESCRIPTION
---
name: update ExpenseChart to use high-contrast color palettes and improve styling
labels: 'gssoc25, hacktoberfest, hacktoberfest-accepted'
assignees: 'Adarsh-Chaubey03'



## 🔗 Related Issue

<!--
Link the related issue using GitHub's linking syntax:
- "Closes #123" - for bug fixes and completed features
-->

- Closes #1411 

## 📝 Summary of Changes

- Updated src/components/TripExpenseCalculator/ExpenseChart.jsx to fix low-contrast pie chart colors.
- Replaced similar pink/red shades with distinct, high-contrast categorical palettes:
- Light: #1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #17becf
- Dark: #4c78a8, #f58518, #54a24b, #e45756, #b279a2, #72b7b2
- Made palette theme-aware via isDarkMode, ensuring visual distinction in both themes.
- Improved slice separation with borders: white in light mode, slate-900 in dark mode; strokeWidth: 2.
- Themed tooltip for readability (background, text, and border adapt to theme).
- Slightly increased outerRadius to 110 for clarity.

## 📸 Screenshots/Demo
BEFORE:

<img width="598" height="622" alt="Screenshot 2025-10-09 212542" src="https://github.com/user-attachments/assets/3db28615-59ef-4e93-9a84-05cc8f234fde" />

AFTER:

<img width="589" height="608" alt="Screenshot 2025-10-10 135959" src="https://github.com/user-attachments/assets/4c4890d8-e2e7-44d5-9c50-ed90cdf88892" />






