### PR TITLE
Fix FAQ Accordion Transition

### DIFF
--- a/client/src/pages/FAQ.jsx
+++ b/client/src/pages/FAQ.jsx
@@ -72,14 +72,19 @@ export default function FAQ() {
               </button>
               <div
                 id={`faq-panel-${idx}`}
-                className={`px-6 pb-5 text-gray-700 text-base transition-all duration-500 ease-in-out ${openIndex === idx ? 'max-h-40 opacity-100' : 'max-h-0 opacity-0'} overflow-hidden`}
-                style={{ transitionProperty: 'max-height, opacity' }}
+                // FIX: The answer content is always rendered, and its visibility is controlled by max-height/opacity.
+                // Added conditional padding to prevent the closed panel from retaining vertical space.
+                className={`px-6 text-gray-700 text-base transition-all duration-500 ease-in-out ${
+                  openIndex === idx 
+                    ? 'max-h-40 opacity-100 pb-5' // Open state with correct bottom padding
+                    : 'max-h-0 opacity-0 pb-0' // Closed state with no bottom padding
+                } overflow-hidden`}
+                style={{ transitionProperty: 'max-height, opacity, padding-bottom' }}
               >
-                {openIndex === idx && (
-                  <div className="animate-fade-in">
-                    {faq.answer}
-                  </div>
-                )}
+                {/* FIX: Answer content is rendered unconditionally */}
+                <div className="animate-fade-in">
+                  {faq.answer}
+                </div>
               </div>
             </div>
           ))}
@@ -87,4 +92,4 @@ export default function FAQ() {
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
---
about: "Fix(FAQ): Enable Smooth Collapse Transition for Accordion Panels"
title: Fix FAQ Accordion Transition
labels: 'gssoc25, hacktoberfest, hacktoberfest-accepted'
assignees: TiwariDivya25

---
### **Description**
This PR fixes a bug in the FAQ accordion where the panel's closing transition was abrupt instead of smooth, despite the presence of transition-all duration-500 classes.

The issue was caused by conditionally rendering the answer content based on the openIndex state ({openIndex === idx && (...) }). This caused React to unmount the answer from the DOM immediately upon closing, prematurely ending the CSS transition.

## 🔗 Related Issue
- Closes #1487 

## 📝 Summary of Changes

- Unconditional Rendering: The answer content is now always rendered in the DOM. The collapse/expand effect is purely controlled by the parent element's CSS classes.
- State-Driven Class Management: The following classes now drive the smooth transition:
- Open: max-h-40 opacity-100 pb-5
- Closed: max-h-0 opacity-0 pb-0 (The pb-0 is crucial to prevent vertical spacing from being retained when the panel is closed).
- Refined Transition Property: Updated the style prop to explicitly include padding-bottom in the transition, resulting in a perfect, smooth slide-up animation.

### **Result ✅**
The FAQ panels now open and close with the intended smooth 500ms transition.
