### PR TITLE
fix: prevent negative and invalid input in Trip Expense Calculator

### DIFF
--- a/client/src/components/TripExpenseCalculator/ExpenseInputRow.jsx
+++ b/client/src/components/TripExpenseCalculator/ExpenseInputRow.jsx
@@ -9,8 +9,34 @@ const ExpenseInputRow = React.memo(({ label, value, onChange, isDarkMode }) => (
     </label>
     <input
       type="number"
+      min={0}
+      step="any"
+      inputMode="decimal"
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        // Block characters that can create negative/invalid numbers
+        if (["-", "+", "e", "E"].includes(e.key)) {
+          e.preventDefault();
+        }
+      }}
+      onPaste={(e) => {
+        const text = (e.clipboardData || window.clipboardData).getData("text");
+        if (!/^\d*(\.?\d*)?$/.test(text)) {
+          e.preventDefault();
+        }
+      }}
+      onChange={(e) => {
+        const val = e.target.value;
+        // Allow clearing the field
+        if (val === "") {
+          onChange("");
+          return;
+        }
+        // Only allow non-negative decimals (intermediate states like "0." are okay)
+        if (/^\d*(\.?\d*)?$/.test(val)) {
+          onChange(val);
+        }
+      }}
       placeholder={`Enter ${label} cost`}
       className={`w-full px-4 py-3 border rounded-xl transition-all  outline-none focus:ring-2 focus:ring-pink-400 ${
         isDarkMode 


### PR DESCRIPTION
---

title: 'prevent negative and invalid input in Trip Expense Calculator'
labels: 'gssoc25, hacktoberfest, hacktoberfest-accepted'
assignees: ''

---

## 🔗 Related Issue

<!--
Link the related issue using GitHub's linking syntax:
- "Closes #123" - for bug fixes and completed features
-->
Input Validation for Trip expense Calculator #1530

- Closes #1530 

## 📝 Summary of Changes

- Added native constraints to the number field: min={0}, step="any", inputMode="decimal".
- Blocked invalid keystrokes: -, +, e, E.
- Prevented pasting invalid text via onPaste.
- Sanitized onChange to allow only empty string or non-negative decimals (supports interim states like 0.), while rejecting negatives.



<!-- 
Thank you for contributing! 🎉

Please ensure you've filled out all relevant sections above. 
The maintainers will review your changes and provide feedback as soon as possible.
-->
