### PR TITLE
Navbar Restructuring & Styling Enhancements to Remain Consistent with the Rest of the Light Mode UI and Footer too.

### DIFF
--- a/client/src/components/Custom/Navbar.jsx
+++ b/client/src/components/Custom/Navbar.jsx
@@ -29,7 +29,6 @@ const Navbar = () => {
   const navLinks = [
     { name: t("navigation.home"), path: "/" },
     { name: t("navigation.trendingSpots"), path: "/trending-spots" },
-    { name: t("navigation.about"), path: "/about" },
     {
       name: t("navigation.booking"),
       subitems: [
@@ -39,16 +38,6 @@ const Navbar = () => {
         { label: "Rentals", path: "/rentals" },
         { label: t("Visa"), path: "/visa-checker" },
         { label: t("navigation.bookingHistory"), path: "/booking-history" },
-      ],
-    },
-    {
-      name: t("navigation.support"),
-      subitems: [
-        { label: t("navigation.travelPlans"), path: "/travel-plan-generator" },
-        { label: t("navigation.customItinerary"), path: "/custom-itinerary" },
-        { label: t("navigation.guide"), path: "/guides" },
-        { label: t("navigation.contact"), path: "/contact" },
-       
       ],
     },
     {
@@ -69,6 +58,15 @@ const Navbar = () => {
       ],
     },
     { name: t("navigation.wishlist"), path: "/wishlist" },
+    {
+      name: t("navigation.support"),
+      subitems: [
+        { label: t("navigation.travelPlans"), path: "/travel-plan-generator" },
+        { label: t("navigation.customItinerary"), path: "/custom-itinerary" },
+        { label: t("navigation.guide"), path: "/guides" },
+        { label: t("navigation.contact"), path: "/contact" },
+      ],
+    },
   ];
 
   // Function to get the active subitem label for dropdown display
@@ -140,8 +138,8 @@ const Navbar = () => {
       <nav
         className={`box-border w-full fixed top-0 left-0 z-50 h-20 backdrop-blur-md border-b transition-all duration-300 pr-4 sm:pr-6 pl-0 ${
           isDarkMode
-            ? "bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 border-slate-700 text-white"
-            : "bg-gradient-to-r from-white via-gray-50 to-white border-gray-200 text-gray-900"
+            ? "bg-slate-900/90 border-slate-700 text-white"
+            : "bg-slate-900/95 border-white/20 text-white"
         } ${isScrolled ? "shadow-xl" : "shadow-md"}`}
       >
         <div className="w-full max-w-full mx-auto flex justify-between items-center gap-6 px-2 py-4.5">
@@ -167,9 +165,7 @@ const Navbar = () => {
 
           {/* Desktop Nav */}
           <div
-            className={`hidden md:flex items-center gap-1.5 font-small flex-1 justify-center ${
-              isDarkMode ? "text-gray-200" : "text-gray-700"
-            }`}
+            className={`hidden md:flex items-center gap-1.5 font-small flex-1 justify-center text-white`}
           >
             {navLinks.map((link) => {
             const activeSubitem = getActiveSubitem(link);
@@ -180,20 +176,18 @@ const Navbar = () => {
                     className={`py-1.5 px-2 text-sm font-medium rounded-sm transition-all  duration-300 flex items-center gap-1 truncate max-w-fit cursor-pointer ${
                       activeParentTab === link.name
                         ? "bg-gradient-to-r from-pink-700 to-pink-500 shadow-md text-white"
-                        : `hover:text-pink-500 hover:shadow-sm ${
-                            isDarkMode ? "text-gray-200" : "text-gray-900"
-                          }`
+                        : `hover:text-pink-500 hover:shadow-sm text-white`
                     }`}
                   >  
                   {/* Chevron rotate on hover */}
-                    {activeSubitem || link.name} <ChevronDown className={`w-4 h-4 transform transition-transform duration-400 group-hover:rotate-180  font-bold ${activeParentTab===link.name? "text-white": 'text-gray-900'}`} />
+                    {activeSubitem || link.name} <ChevronDown className={`w-4 h-4 transform transition-transform duration-400 group-hover:rotate-180  font-bold text-white`} />
                   </button>
                   {/* Dropdown menu */}
                   <div
                     className={`absolute left-0 mt-0 top-full opacity-0 invisible group-hover:visible group-hover:opacity-100 transition-all duration-300 z-50 p-2 min-w-[200px] max-w-[280px] rounded-lg shadow-lg ${
                       isDarkMode
                         ? "bg-slate-800 text-white border border-slate-700"
-                        : "bg-white text-gray-900 border border-gray-200"
+                        : "bg-white/90 backdrop-blur-xl text-black border-2 border-white/40 shadow-xl"
                     }`}
                   >
                     {link.subitems.map((item) => (
@@ -219,7 +213,7 @@ const Navbar = () => {
                   to={link.path}
                   end
                   className={({ isActive }) =>
-                    `${linkBaseClasses} ${
+                    `${linkBaseClasses} text-white ${
                       isActive
                         ? "bg-gradient-to-r from-pink-700 to-pink-500 shadow-md text-white hover:text-white "
                         : ""
@@ -233,7 +227,7 @@ const Navbar = () => {
           </div>
 
           {/* Desktop Auth Buttons and Theme Toggle */}
-          <div className="hidden md:flex gap-3 items-center text-pink-500 font-medium">
+          <div className="hidden md:flex gap-3 items-center text-white font-medium">
             {/* Mood Toggle */}
             <MoodToggle />
             {/* Language Selector */}
@@ -287,13 +281,13 @@ const Navbar = () => {
               <>
                 <NavLink
                   to="/login"
-                  className="bg-gradient-to-r from-pink-200 to-pink-200 text-black px-3 py-2 rounded-md font-semibold hover:scale-105 transition-all text-sm whitespace-nowrap"
+                  className="bg-white text-black px-3 py-2 rounded-md font-semibold hover:scale-105 transition-all text-sm whitespace-nowrap"
                 >
                   {t("auth.login")}
                 </NavLink>
                 <NavLink
                   to="/signup"
-                  className="bg-gradient-to-r from-pink-200 to-pink-200 text-black px-3 py-2 rounded-md font-semibold hover:scale-105 transition-all text-sm whitespace-nowrap"
+                  className="bg-pink-400 text-white px-3 py-2 rounded-md font-semibold hover:scale-105 transition-all text-sm whitespace-nowrap"
                 >
                   {t("auth.signup")}
                 </NavLink>
@@ -352,13 +346,13 @@ const Navbar = () => {
             isDarkMode ? "border-gray-600" : "border-gray-300"
           }`}>
             <div className="flex items-center justify-between px-3">
-              <span className={`text-sm font-medium ${isDarkMode ? "text-gray-300" : "text-gray-700"}`}>
+              <span className={`text-sm font-medium text-white`}>
                 Mood Music
               </span>
               <MoodToggle />
             </div>
             <div className="flex items-center justify-between px-3">
-              <span className={`text-sm font-medium ${isDarkMode ? "text-gray-300" : "text-gray-700"}`}>
+              <span className={`text-sm font-medium text-white`}>
                 Language
               </span>
               <LanguageSelector />

--- a/client/src/components/LanguageSelector.jsx
+++ b/client/src/components/LanguageSelector.jsx
@@ -44,10 +44,10 @@ const LanguageSelector = () => {
         <div className="relative" ref={dropdownRef}>
             <button
                 onClick={() => setIsOpen(!isOpen)}
-                className={`flex items-center gap-2 px-3 py-2 rounded-md transition-all duration-200 hover:bg-pink-500/20 ${
+                className={`flex items-center gap-2 px-3 py-2 rounded-md transition-all duration-200 ${
                     isDarkMode
-                        ? "text-gray-200 hover:text-white"
-                        : "text-gray-700 hover:text-gray-900"
+                        ? "text-gray-200 hover:text-white hover:bg-pink-500/20"
+                        : "text-white hover:text-white"
                 }`}
                 aria-label="Select language"
             >
@@ -69,7 +69,7 @@ const LanguageSelector = () => {
                     className={`absolute right-0 mt-2 w-48 rounded-lg shadow-lg border z-50 ${
                         isDarkMode
                             ? "bg-slate-800 border-slate-700 text-white"
-                            : "bg-white border-gray-200 text-gray-900"
+                            : "bg-white/90 backdrop-blur-xl border-2 border-white/40 text-black"
                     }`}
                 >
                     <div className="py-1">


### PR DESCRIPTION
---
name: Pull Request Template
about: "Use this format for all pull requests."
title: 'Enhance Light Mode Navbar Contrast for Better Visual Separation, Contrast and Remove Redundant features'
labels: 'gssoc25, hacktoberfest, hacktoberfest-accepted, level 2'
assignees: 'Granger007'

---

## 🔗 Related Issue

- Closes #1583 

## 📝 Summary of Changes

- Reorganized navbar links: Home | Trending Spots | Booking | Tools | Wishlist | Support (removed “About”).

- Unified light mode styling with footer — bg-slate-900/95, white text, and border consistency.

- Added glassmorphic dropdowns with white outlines and black text.

- Updated UI components (auth buttons, icons, language selector) for better contrast.

- Maintained existing dark mode styling.

## 📸 Screenshots/Demo

BEFORE

<img width="1886" height="888" alt="image" src="https://github.com/user-attachments/assets/c0242bf7-d507-4eb1-885f-ab22b55edec6" />

AFTER

<img width="1892" height="880" alt="image" src="https://github.com/user-attachments/assets/ac44b88a-ff01-4817-aee6-751c573c111b" />


---

<!-- 
Thank you for contributing! 🎉

Please ensure you've filled out all relevant sections above. 
The maintainers will review your changes and provide feedback as soon as possible.
-->
