### PR TITLE
[FIX]: #1618 Scroll Dots Visibility in Light Mode 

### DIFF
--- a/client/src/components/Custom/CustomCarousel.jsx
+++ b/client/src/components/Custom/CustomCarousel.jsx
@@ -167,10 +167,10 @@ const CustomCarousel = ({ guides, viewprofilehandle, isHome = false }) => {
 						onClick={() => setCurrentIndex(index)}
 						className={`w-3 h-3 rounded-full transition-all duration-300 ${
 							currentIndex === index
-								? "bg-pink-500 scale-110"
-								: isDarkMode
-								? "bg-gray-500"
-								: "bg-gray-300"
+							? "bg-pink-500 scale-110" // Active dot (no change)
+							: isDarkMode
+							? "bg-pink-700 hover:bg-pink-600" // Inactive dot (Dark Mode) - Lighter
+							: "bg-pink-300 hover:bg-pink-400" // Inactive dot (Light Mode) - Darker
 						}`}
 					/>
 				))}


### PR DESCRIPTION


## 🔗 Related Issue

- Closes #1618 

## 📝 Summary of Changes

Updated the color of the inactive carousel dots to match the website's pink theme, replacing the previous gray.

- In **light mode**, the inactive dots are now a darker, more visible `bg-pink-300`.  
- In **dark mode**, the inactive dots are now a lighter, more distinct `bg-pink-700` to improve contrast.  

This change enhances the visual consistency of the component and ensures the pagination dots are clearly visible in both light and dark modes.

## 📸 Screenshots/Demo

*Before:* (Inactive dots were `bg-gray-300` in light mode and `bg-gray-500` in dark mode)

https://github.com/user-attachments/assets/9e8e00ad-98ad-4f9c-9e01-8a0f8ee5fe79

  
*After:* (Inactive dots are now themed pink, with `bg-pink-300` in light mode and `bg-pink-700` in dark mode)  

https://github.com/user-attachments/assets/db6ec7db-785a-472b-b5ac-5cccf2fb87a6





---